### PR TITLE
Implement tls local testing

### DIFF
--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -19,7 +19,7 @@ String robotTestSelection(String tests, String customTest) {
 }
 
 String setupLocalCapifPort(String localCapif) {
-    return (localCapif) ? '8080' : ''
+    return (localCapif) ? '' : '8080'
 }
 
 test_plan = [

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -18,8 +18,8 @@ String robotTestSelection(String tests, String customTest) {
     return tests == 'NONE' ? ' ' : '--include ' + test_plan[tests]
 }
 
-String setupLocalCapifPort(boolean local_capif) {
-    if (local_capif) {
+String setupLocalCapifPort(String localCapif) {
+    if (localCapif == 'true' ) {
         return '8080'
     }
     return ''

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -18,7 +18,7 @@ String robotTestSelection(String tests, String customTest) {
     return tests == 'NONE' ? ' ' : '--include ' + test_plan[tests]
 }
 
-String setup_local_port(boolean local_capif) {
+String setupLocalCapifPort(boolean local_capif) {
     if (local_capif) {
         return '8080'
     }
@@ -67,7 +67,7 @@ pipeline {
         ROBOT_VERSION = robotDockerVersion("${params.ROBOT_DOCKER_IMAGE_VERSION}")
         ROBOT_IMAGE_NAME = 'dockerhub.hi.inet/5ghacking/evolved-robot-test-image'
         RUN_LOCAL_CAPIF = "${params.RUN_LOCAL_CAPIF}"
-        CAPIF_HTTP_PORT = setup_local_port("${params.RUN_LOCAL_CAPIF}")
+        CAPIF_HTTP_PORT = setupLocalCapifPort("${params.RUN_LOCAL_CAPIF}")
     }
     stages {
         stage ('Prepare testing tools') {

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -18,10 +18,6 @@ String robotTestSelection(String tests, String customTest) {
     return tests == 'NONE' ? ' ' : '--include ' + test_plan[tests]
 }
 
-String setupLocalCapifPort(String localCapif) {
-    return (localCapif) ? ' ' : '8080'
-}
-
 test_plan = [
     'All Capif Services': 'all',
     'CAPIF Api Invoker Management': 'capif_api_invoker_management',

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -21,9 +21,8 @@ String robotTestSelection(String tests, String customTest) {
 String setup_local_port(boolean local_capif) {
     if (local_capif) {
         return '8080'
-    } else {
-        return ''
     }
+    return ''
 }
 
 test_plan = [

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -64,7 +64,6 @@ pipeline {
         ROBOT_VERSION = robotDockerVersion("${params.ROBOT_DOCKER_IMAGE_VERSION}")
         ROBOT_IMAGE_NAME = 'dockerhub.hi.inet/5ghacking/evolved-robot-test-image'
         RUN_LOCAL_CAPIF = "${params.RUN_LOCAL_CAPIF}"
-        CAPIF_HTTP_PORT = setupLocalCapifPort("${params.RUN_LOCAL_CAPIF}")
     }
     stages {
         stage ('Prepare testing tools') {
@@ -91,6 +90,9 @@ pipeline {
                 expression { RUN_LOCAL_CAPIF == 'true' }
             }
             steps {
+                script {
+                    env.CAPIF_HTTP_PORT = "8080"
+                }
                 dir ("${CAPIF_SERVICES_DIRECTORY}") {
                         sh '''
                             ./run.sh ${CAPIF_HOSTNAME}

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -19,10 +19,7 @@ String robotTestSelection(String tests, String customTest) {
 }
 
 String setupLocalCapifPort(String localCapif) {
-    if (localCapif == 'true' ) {
-        return '8080'
-    }
-    return ''
+    return (localCapif) ? '8080' : ''
 }
 
 test_plan = [

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -19,7 +19,7 @@ String robotTestSelection(String tests, String customTest) {
 }
 
 String setupLocalCapifPort(String localCapif) {
-    return (localCapif) ? '' : '8080'
+    return (localCapif) ? ' ' : '8080'
 }
 
 test_plan = [

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -108,7 +108,9 @@ pipeline {
             steps {
                 dir ("${env.WORKSPACE}") {
                     sh """
+                        echo "Retrieve docker image"
                         docker pull ${ROBOT_IMAGE_NAME}:${ROBOT_VERSION}
+                        echo "Executing tests"
                         docker run -t \
                             --network="host" \
                             --rm \

--- a/pac/Jenkinsfile-capif-tests.groovy
+++ b/pac/Jenkinsfile-capif-tests.groovy
@@ -18,6 +18,14 @@ String robotTestSelection(String tests, String customTest) {
     return tests == 'NONE' ? ' ' : '--include ' + test_plan[tests]
 }
 
+String setup_local_port(boolean local_capif) {
+    if (local_capif) {
+        return '8080'
+    } else {
+        return ''
+    }
+}
+
 test_plan = [
     'All Capif Services': 'all',
     'CAPIF Api Invoker Management': 'capif_api_invoker_management',
@@ -60,6 +68,7 @@ pipeline {
         ROBOT_VERSION = robotDockerVersion("${params.ROBOT_DOCKER_IMAGE_VERSION}")
         ROBOT_IMAGE_NAME = 'dockerhub.hi.inet/5ghacking/evolved-robot-test-image'
         RUN_LOCAL_CAPIF = "${params.RUN_LOCAL_CAPIF}"
+        CAPIF_HTTP_PORT = setup_local_port("${params.RUN_LOCAL_CAPIF}")
     }
     stages {
         stage ('Prepare testing tools') {
@@ -111,6 +120,7 @@ pipeline {
                             -v ${ROBOT_RESULTS_DIRECTORY}:/opt/robot-tests/results \
                             ${ROBOT_IMAGE_NAME}:${ROBOT_VERSION} \
                             --variable CAPIF_HOSTNAME:${CAPIF_HOSTNAME} \
+                            --variable CAPIF_HTTP_PORT:${CAPIF_HTTP_PORT} \
                             ${ROBOT_TESTS_INCLUDE} ${ROBOT_TEST_OPTIONS}
                     """
                 }

--- a/tests/features/CAPIF Api Publish Service/capif_api_publish_service.robot
+++ b/tests/features/CAPIF Api Publish Service/capif_api_publish_service.robot
@@ -23,7 +23,7 @@ Publish API by Authorised API Publisher
     ${resp}=    Post Request Capif
     ...    sign-csr
     ...    json=${request_body}
-    ...    server=http://${CAPIF_HOSTNAME}/
+    ...    server=${CAPIF_HTTP_URL}
     ...    verify=ca.crt
     ...    access_token=${register_user_info['access_token']}
     Status Should Be    201    ${resp}

--- a/tests/features/__init__.robot
+++ b/tests/features/__init__.robot
@@ -6,12 +6,16 @@ Suite Setup     Prepare environment
 Force Tags      all
 
 
-*** Variables ***
-
-
 *** Keywords ***
 Prepare environment
     Log    ${CAPIF_HOSTNAME}
+    Log    "${CAPIF_HTTP_PORT}"
+
+    Set Global Variable    ${CAPIF_HTTP_URL}    http://${CAPIF_HOSTNAME}/
+    IF    "${CAPIF_HTTP_PORT}" != ""
+        Set Global Variable    ${CAPIF_HTTP_URL}    http://${CAPIF_HOSTNAME}:${CAPIF_HTTP_PORT}/
+    END
+
     ${status}    ${CAPIF_IP}=    Run Keyword And Ignore Error    Get Ip From Hostname    ${CAPIF_HOSTNAME}
 
     IF    "${status}" == "PASS"
@@ -28,7 +32,7 @@ Prepare environment
 
 Retrieve Ca Root
     [Documentation]    This keyword retrieve ca.root from CAPIF and store it at ca.crt in order to use at TLS communications
-    ${resp}=    Get Request Capif    /ca-root    server=http://${CAPIF_HOSTNAME}
+    ${resp}=    Get Request Capif    /ca-root    server=${CAPIF_HTTP_URL}
     Status Should Be    201    ${resp}
     Log    ${resp.json()['certificate']}
     Store In File    ca.crt    ${resp.json()['certificate']}

--- a/tests/resources/common.resource
+++ b/tests/resources/common.resource
@@ -11,6 +11,7 @@ ${INVOKER_ROLE}                 invoker
 ${PUBLISHER_ROLE}               apf
 
 ${CAPIF_HOSTNAME}               capifcore
+${CAPIF_HTTP_PORT}
 ${CAPIF_IP}                     127.0.0.1
 ${CAPIF_CALLBACK_IP}            host.docker.internal
 ${CAPIF_CALLBACK_PORT}          8086

--- a/tests/resources/common/basicRequests.robot
+++ b/tests/resources/common/basicRequests.robot
@@ -126,7 +126,7 @@ Register User At Jwt Auth
     ...    description=${description}
     ...    cn=${username}
 
-    Create Session    jwtsession    http://${CAPIF_HOSTNAME}    verify=True
+    Create Session    jwtsession    ${CAPIF_HTTP_URL}    verify=True
 
     ${resp}=    POST On Session    jwtsession    /register    json=${body}
 
@@ -156,7 +156,7 @@ Get Token For User
     RETURN    ${resp.json()["access_token"]}
 
 Clean Test Information By HTTP Requests
-    Create Session    jwtsession    http://${CAPIF_HOSTNAME}   verify=True
+    Create Session    jwtsession    ${CAPIF_HTTP_URL}   verify=True
 
     ${resp}=    DELETE On Session    jwtsession    /testdata
     Should Be Equal As Strings    ${resp.status_code}    200
@@ -201,7 +201,7 @@ Publisher Default Registration
     ${resp}=    Post Request Capif
     ...    sign-csr
     ...    json=${request_body}
-    ...    server=http://${CAPIF_HOSTNAME}/
+    ...    server=${CAPIF_HTTP_URL}
     ...    verify=ca.crt
     ...    access_token=${register_user_info['access_token']}
     Status Should Be    201    ${resp}


### PR DESCRIPTION
This changes are made to allow local testing on users machine. CAPIF_HTTP_PORT port must be set to 8080 to test locally, if we leave it empty tests will reach standar http port (80) for non TLS flows.
