### PR TITLE
Perf tests

### DIFF
--- a/perf_tests/features/CAPIF Api Auditing Service/__init__.robot
+++ b/perf_tests/features/CAPIF Api Auditing Service/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_auditing_service

--- a/perf_tests/features/CAPIF Api Auditing Service/capif_auditing_api.robot
+++ b/perf_tests/features/CAPIF Api Auditing Service/capif_auditing_api.robot
@@ -1,0 +1,104 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+Library         Collections
+Resource        /opt/robot-tests/tests/resources/common/basicRequests.robot
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+
+Test Setup      Reset Testing Environment
+
+*** Variables ***
+${AEF_ID_NOT_VALID}             aef-example
+${SERVICE_API_ID_NOT_VALID}     not-valid
+${API_INVOKER_NOT_VALID}        not-valid
+${NOTIFICATION_DESTINATION}     http://robot.testing:1080
+${API_VERSION_VALID}            v1
+${API_VERSION_NOT_VALID}        v58
+
+*** Test Cases ***
+Get Log Entry Performance
+    [Tags]    capif_api_auditing_service-1
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    # Publish one api
+    Publish Service Api    ${register_user_info}
+
+    #Register INVOKER
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${discover_response}=    Get Request Capif
+    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    ${api_ids}   ${api_names}=    Get Api Ids And Names From Discover Response    ${discover_response}
+
+    # Create Log Entry
+    ${request_body}=  Create Log Entry  ${register_user_info['aef_id']}  ${register_user_info_invoker['api_invoker_id']}  ${api_ids}  ${api_names}
+    ${resp_1}=    Post Request Capif
+    ...    /api-invocation-logs/v1/${register_user_info['aef_id']}/logs
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${AEF_PROVIDER_USERNAME}
+
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp_2}=    Get Request Capif
+        ...    /logs/v1/apiInvocationLogs?aef-id=${register_user_info['aef_id']}&api-invoker-id=${register_user_info_invoker['api_invoker_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AMF_PROVIDER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp_2}    200    InvocationLog
+        Length Should Be   ${resp_2.json()["logs"]}  2
+
+        ${success}       ${average}      Handle Timing       ${resp_2.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+Get a log entry without entry created performance
+    [Tags]    capif_api_auditing_service-2
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    # Publish one api
+    Publish Service Api    ${register_user_info}
+
+    #Register INVOKER
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp_1}=  Get Request Capif
+        ...    /logs/v1/apiInvocationLogs?aef-id=${register_user_info['aef_id']}&api-invoker-id=${register_user_info_invoker['api_invoker_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AMF_PROVIDER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp_1}    404   ProblemDetails
+        ...    title=Not Found
+        ...    status=404
+        ...    detail=aefId or/and apiInvokerId do not match any InvocationLogs
+        ...    cause=No log invocations found
+
+        ${success}       ${average}      Handle Timing       ${resp_1.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}

--- a/perf_tests/features/CAPIF Api Discover Service/__init__.robot
+++ b/perf_tests/features/CAPIF Api Discover Service/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_discover_service

--- a/perf_tests/features/CAPIF Api Discover Service/capif_api_service_discover.robot
+++ b/perf_tests/features/CAPIF Api Discover Service/capif_api_service_discover.robot
@@ -1,0 +1,217 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Resource        /opt/robot-tests/tests/resources/api_invoker_management_requests/apiInvokerManagementRequests.robot
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+
+Test Setup      Reset Testing Environment
+# Test Setup    Initialize Test And Register    role=invoker
+
+
+*** Variables ***
+${API_INVOKER_NOT_REGISTERED}       not-valid
+
+
+*** Test Cases ***
+Discover Published service APIs by Authorised API Invoker Performance
+    [Tags]    capif_api_discover_service-1
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    # Publish one api
+    ${service_api_description_published}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Test
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Get Request Capif
+        ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&aef-id=${register_user_info['aef_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    DiscoveredAPIs
+
+        # Check Results
+        Dictionary Should Contain Key    ${resp.json()}    serviceAPIDescriptions
+        Should Not Be Empty    ${resp.json()['serviceAPIDescriptions']}
+        Length Should Be    ${resp.json()['serviceAPIDescriptions']}    1
+        List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+Discover Published service APIs by registered API Invoker with 1 result filtered performance
+    [Tags]    capif_api_discover_service-4
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${api_name_1}=    Set Variable    service_1
+    ${api_name_2}=    Set Variable    service_2
+
+    # Publish 2 apis
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    ${api_name_1}
+    ${service_api_description_published_2}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    ${api_name_2}
+
+    # Register INVOKER
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Request all APIs for Invoker
+    ${resp}=    Get Request Capif
+    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&aef-id=${register_user_info['aef_id']}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    Check Response Variable Type And Values    ${resp}    200    DiscoveredAPIs
+
+    # Check returned values
+    Should Not Be Empty    ${resp.json()['serviceAPIDescriptions']}
+    Length Should Be    ${resp.json()['serviceAPIDescriptions']}    2
+    List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_1}
+    List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_2}
+
+    # Request api 1
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Get Request Capif
+        ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&api-name=${api_name_1}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    DiscoveredAPIs
+
+        # Check Results
+        Should Not Be Empty    ${resp.json()['serviceAPIDescriptions']}
+        Length Should Be    ${resp.json()['serviceAPIDescriptions']}    1
+        List Should Contain Value    ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_1}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+Discover Published service APIs by registered API Invoker filtered with no match performance
+    [Tags]    capif_api_discover_service-5
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${api_name_1}=    Set Variable    apiName1
+    ${api_name_2}=    Set Variable    apiName2
+
+    # Publish 2 apis
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    ${api_name_1}
+    ${service_api_description_published_2}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    ${api_name_2}
+
+    # Change to invoker role and register at api invoker management
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Request all APIs for Invoker
+    ${resp}=    Get Request Capif
+    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&aef-id=${register_user_info['aef_id']}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    Check Response Variable Type And Values    ${resp}    200    DiscoveredAPIs
+
+    # Check returned values
+    Should Not Be Empty    ${resp.json()['serviceAPIDescriptions']}
+    Length Should Be    ${resp.json()['serviceAPIDescriptions']}    2
+    List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_1}
+    List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_2}
+
+    # Request api 1
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Get Request Capif
+        ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&api-name=NOT_VALID_NAME
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+        ...    title=Not Found
+        ...    status=404
+        ...    detail=API Invoker ${register_user_info_invoker['api_invoker_id']} has no API Published that accomplish filter conditions
+        ...    cause=No API Published accomplish filter conditions
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+Discover Published service APIs by registered API Invoker not filtered performance
+    [Tags]    capif_api_discover_service-6
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${api_name_1}=    Set Variable    apiName1
+    ${api_name_2}=    Set Variable    apiName2
+
+    # Publish 2 apis
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    ${api_name_1}
+    ${service_api_description_published_2}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    ${api_name_2}
+
+    # Change to invoker role and register at api invoker management
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Request all APIs for Invoker
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Get Request Capif
+        ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&aef-id=${register_user_info['aef_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    DiscoveredAPIs
+
+        # Check Results
+        Should Not Be Empty    ${resp.json()['serviceAPIDescriptions']}
+        Length Should Be    ${resp.json()['serviceAPIDescriptions']}    2
+        List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_1}
+        List Should Contain Value   ${resp.json()['serviceAPIDescriptions']}    ${service_api_description_published_2}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}

--- a/perf_tests/features/CAPIF Api Events/__init__.robot
+++ b/perf_tests/features/CAPIF Api Events/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_events

--- a/perf_tests/features/CAPIF Api Events/capif_events_api.robot
+++ b/perf_tests/features/CAPIF Api Events/capif_events_api.robot
@@ -1,0 +1,162 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+Library         XML
+Resource        /opt/robot-tests/tests/resources/common/basicRequests.robot
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+
+Test Setup      Reset Testing Environment
+
+
+*** Variables ***
+${API_INVOKER_NOT_REGISTERED}       not-valid
+${SUBSCRIBER_ID_NOT_VALID}          not-valid
+${SUBSCRIPTION_ID_NOT_VALID}        not-valid
+
+
+*** Test Cases ***
+Creates a new individual CAPIF Event Subscription Performance
+    [Tags]    capif_api_events-1
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${request_body}=    Create Events Subscription
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        ${resp}=    Post Request Capif
+        ...    /capif-events/v1/${register_user_info_invoker['api_invoker_id']}/subscriptions
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    201    EventSubscription
+        ${subscriber_id}    ${subscription_id}=    Check Event Location Header    ${resp}
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Creates a new individual CAPIF Event Subscription with Invalid SubscriberId
+#    [Tags]    capif_api_events-2
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Events Subscription
+#    ${resp}=    Post Request Capif
+#    ...    /capif-events/v1/${SUBSCRIBER_ID_NOT_VALID}/subscriptions
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values  ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker or APF or AEF or AMF Not found
+#    ...    cause=Subscriber Not Found
+
+Deletes an individual CAPIF Event Subscription Performance
+    [Tags]    capif_api_events-3
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${request_body}=    Create Events Subscription
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        ${resp}=    Post Request Capif
+        ...    /capif-events/v1/${register_user_info_invoker['api_invoker_id']}/subscriptions
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    201    EventSubscription
+
+        ${subscriber_id}    ${subscription_id}=    Check Event Location Header    ${resp}
+
+        ${resp}=    Delete Request Capif
+        ...    /capif-events/v1/${subscriber_id}/subscriptions/${subscription_id}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Status Should Be    204    ${resp}
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Deletes an individual CAPIF Event Subscription with invalid SubscriberId
+#    [Tags]    capif_api_events-4
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Events Subscription
+#    ${resp}=    Post Request Capif
+#    ...    /capif-events/v1/${register_user_info_invoker['api_invoker_id']}/subscriptions
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    EventSubscription
+#
+#    ${subscriber_id}    ${subscription_id}=    Check Event Location Header    ${resp}
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /capif-events/v1/${SUBSCRIBER_ID_NOT_VALID}/subscriptions/${subscription_id}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values  ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker or APF or AEF or AMF Not found
+#    ...    cause=Subscriber Not Found
+
+
+#Deletes an individual CAPIF Event Subscription with invalid SubscriptionId
+#    [Tags]    capif_api_events-5
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Events Subscription
+#    ${resp}=    Post Request Capif
+#    ...    /capif-events/v1/${register_user_info_invoker['api_invoker_id']}/subscriptions
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    EventSubscription
+#
+#    ${subscriber_id}    ${subscription_id}=    Check Event Location Header    ${resp}
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /capif-events/v1/${subscriber_id}/subscriptions/${SUBSCRIPTION_ID_NOT_VALID}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values  ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Event subscription not exist
+#    ...    cause=Event API subscription id not found
+#

--- a/perf_tests/features/CAPIF Api Invoker Management/__init__.robot
+++ b/perf_tests/features/CAPIF Api Invoker Management/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_invoker_management

--- a/perf_tests/features/CAPIF Api Invoker Management/capif_api_invoker_managenet.robot
+++ b/perf_tests/features/CAPIF Api Invoker Management/capif_api_invoker_managenet.robot
@@ -1,0 +1,325 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Resource        /opt/robot-tests/tests/resources/performance.resource
+Resource        /opt/robot-tests/tests/resources/api_invoker_management_requests/apiInvokerManagementRequests.robot
+Resource    ../../resources/common.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+Library         Process
+Library         Collections
+
+Test Setup      Reset Testing Environment
+
+
+*** Variables ***
+${API_INVOKER_NOT_REGISTERED}       not-valid
+
+
+*** Test Cases ***
+Onboard NetApp Performance
+    [Tags]    capif_api_invoker_management-1
+    #Register Netapp
+    ${register_user_info}=    Register User At Jwt Auth
+    ...    username=${INVOKER_USERNAME}    role=${INVOKER_ROLE}
+
+    # Send Onboarding Request
+    ${request_body}=    Create Onboarding Notification Body
+    ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_callback
+    ...    ${register_user_info['csr_request']}
+    ...    ${INVOKER_USERNAME}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Post Request Capif
+        ...    ${register_user_info['ccf_onboarding_url']}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    access_token=${register_user_info['access_token']}
+
+        # Upkeep for deletion later
+        Set To Dictionary    ${register_user_info}    api_invoker_id=${resp.json()['apiInvokerId']}
+        ${url}=    Parse Url    ${resp.headers['Location']}
+
+        # Check Results
+        Check Response Variable Type And Values  ${resp}  201  APIInvokerEnrolmentDetails
+        Check Location Header    ${resp}    ${LOCATION_INVOKER_RESOURCE_REGEX}
+
+        # Store dummy signed certificate
+        Store In File    ${INVOKER_USERNAME}.crt    ${resp.json()['onboardingInformation']['apiInvokerCertificate']}
+
+
+        IF  ${index} < ${ITERATIONS}-${1} # Offboard Netapp (Not on last iteration)
+            ${offb}=    Delete Request Capif
+            ...    ${url.path}
+            ...    server=${CAPIF_HTTPS_URL}
+            ...    verify=ca.crt
+            ...    username=${INVOKER_USERNAME}
+
+            # Check Results
+            Should Be Equal As Strings    ${offb.status_code}    204
+        END
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+
+#Register NetApp Already Onboarded
+#    [Tags]    capif_api_invoker_management-2
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${resp}=    Post Request Capif
+#    ...    ${register_user_info['ccf_onboarding_url']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    access_token=${register_user_info['access_token']}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    403    ProblemDetails
+#    ...    status=403
+#    ...    title=Forbidden
+#    ...    detail=Invoker already registered
+#    ...    cause=Identical invoker public key
+
+Update Onboarded NetApp Performance
+    [Tags]    capif_api_invoker_management-3
+    ${new_notification_destination}=    Set Variable
+    ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_new_callback
+    # Default Invoker Registration and Onboarding
+    ${register_user_info}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    Set To Dictionary
+    ...    ${request_body}
+    ...    notificationDestination=${new_notification_destination}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Put Request Capif
+        ...    ${url.path}
+        ...    ${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    200    APIInvokerEnrolmentDetails
+        ...    notificationDestination=${new_notification_destination}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Update Not Onboarded NetApp
+#    [Tags]    capif_api_invoker_management-4
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${resp}=    Put Request Capif
+#    ...    /api-invoker-management/v1/onboardedInvokers/${INVOKER_NOT_REGISTERED}
+#    ...    ${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    status=404
+#    ...    title=Not Found
+#    ...    detail=Please provide an existing Netapp ID
+#    ...    cause=Not exist NetappID
+
+Offboard NetApp Performance
+    [Tags]    capif_api_invoker_management-5
+    # Register User
+    ${register_user_info}=    Register User At Jwt Auth
+    ...    username=${INVOKER_USERNAME}    role=${INVOKER_ROLE}
+
+    # Send Onboarding Request
+    ${request_body}=    Create Onboarding Notification Body
+    ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_callback
+    ...    ${register_user_info['csr_request']}
+    ...    ${INVOKER_USERNAME}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # Onboard Netapp
+        ${resp}=    Post Request Capif
+        ...    ${register_user_info['ccf_onboarding_url']}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    access_token=${register_user_info['access_token']}
+
+        # Upkeep for deletion later
+        Set To Dictionary    ${register_user_info}    api_invoker_id=${resp.json()['apiInvokerId']}
+        ${url}=    Parse Url    ${resp.headers['Location']}
+
+        # Check Results
+        Check Response Variable Type And Values  ${resp}  201  APIInvokerEnrolmentDetails
+        Check Location Header    ${resp}    ${LOCATION_INVOKER_RESOURCE_REGEX}
+
+        # Store dummy signed certificate
+        Store In File    ${INVOKER_USERNAME}.crt    ${resp.json()['onboardingInformation']['apiInvokerCertificate']}
+
+        # Offboard Netapp
+        ${resp}=    Delete Request Capif
+        ...    ${url.path}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        # Check Results
+        Should Be Equal As Strings    ${resp.status_code}    204
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Offboard Not Previously Onboarded NetApp
+#    [Tags]    capif_api_invoker_management-6
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /api-invoker-management/v1/onboardedInvokers/${INVOKER_NOT_REGISTERED}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    status=404
+#    ...    title=Not Found
+#    ...    detail=Please provide an existing Netapp ID
+#    ...    cause=Not exist NetappID
+
+Update Onboarded NetApp Certificate Performance
+    [Tags]    capif_api_invoker_management-7
+    ${new_notification_destination}=    Set Variable
+    ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_new_callback
+    # Default Invoker Registration and Onboarding
+    ${register_user_info}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        ${INVOKER_USERNAME_NEW}=   Set Variable     ${INVOKER_USERNAME}_NEW_${index}
+
+        ${csr_request_new}=    Create User Csr    ${INVOKER_USERNAME_NEW}    invoker
+
+        ${new_onboarding_notification_body}=    Create Onboarding Notification Body
+        ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_callback
+        ...    ${csr_request_new}
+        ...    ${INVOKER_USERNAME}
+
+        Set To Dictionary
+        ...    ${request_body}
+        ...    onboardingInformation=${new_onboarding_notification_body['onboardingInformation']}
+
+        ${cert_resp}=    Put Request Capif
+        ...    ${url.path}
+        ...    ${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${cert_resp}    200    APIInvokerEnrolmentDetails
+
+        Store In File    ${INVOKER_USERNAME_NEW}.crt    ${cert_resp.json()['onboardingInformation']['apiInvokerCertificate']}
+
+        Set To Dictionary
+        ...    ${request_body}
+        ...    notificationDestination=${new_notification_destination}
+
+        ${note_resp}=    Put Request Capif
+        ...    ${url.path}
+        ...    ${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME_NEW}
+
+        # Check Results
+        Check Response Variable Type And Values    ${note_resp}    200    APIInvokerEnrolmentDetails
+        ...    notificationDestination=${new_notification_destination}
+
+        ${success}       ${average}      Handle Timing       ${cert_resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+Update Onboarded NetApp Notification Destination Performance  # New!
+    [Tags]    capif_api_invoker_management-7
+    ${new_notification_destination}=    Set Variable
+    ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_new_callback
+    # Default Invoker Registration and Onboarding
+    ${register_user_info}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        ${INVOKER_USERNAME_NEW}=   Set Variable     ${INVOKER_USERNAME}_NEW_${index}
+
+        ${csr_request_new}=    Create User Csr    ${INVOKER_USERNAME_NEW}    invoker
+
+        ${new_onboarding_notification_body}=    Create Onboarding Notification Body
+        ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_callback
+        ...    ${csr_request_new}
+        ...    ${INVOKER_USERNAME}
+
+        Set To Dictionary
+        ...    ${request_body}
+        ...    onboardingInformation=${new_onboarding_notification_body['onboardingInformation']}
+
+        ${cert_resp}=    Put Request Capif
+        ...    ${url.path}
+        ...    ${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${cert_resp}    200    APIInvokerEnrolmentDetails
+
+        Store In File    ${INVOKER_USERNAME_NEW}.crt    ${cert_resp.json()['onboardingInformation']['apiInvokerCertificate']}
+
+        Set To Dictionary
+        ...    ${request_body}
+        ...    notificationDestination=${new_notification_destination}
+
+        ${note_resp}=    Put Request Capif
+        ...    ${url.path}
+        ...    ${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME_NEW}
+
+        # Check Results
+        Check Response Variable Type And Values    ${note_resp}    200    APIInvokerEnrolmentDetails
+        ...    notificationDestination=${new_notification_destination}
+
+        ${success}       ${average}      Handle Timing       ${note_resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}

--- a/perf_tests/features/CAPIF Api Logging Service/__init__.robot
+++ b/perf_tests/features/CAPIF Api Logging Service/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_logging_service

--- a/perf_tests/features/CAPIF Api Logging Service/capif_logging_api.robot
+++ b/perf_tests/features/CAPIF Api Logging Service/capif_logging_api.robot
@@ -1,0 +1,200 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+Library         Collections
+Resource        /opt/robot-tests/tests/resources/common/basicRequests.robot
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+
+Test Setup      Reset Testing Environment
+
+*** Variables ***
+${AEF_ID_NOT_VALID}             aef-example
+${SERVICE_API_ID_NOT_VALID}     not-valid
+${API_INVOKER_NOT_VALID}        not-valid
+${NOTIFICATION_DESTINATION}     http://robot.testing:1080
+
+*** Test Cases ***
+Create a log entry Performance
+    [Tags]    capif_api_logging_service-1
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    # Publish one api
+    Publish Service Api    ${register_user_info}
+
+    #Register INVOKER
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${discover_response}=    Get Request Capif
+    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    ${api_ids}   ${api_names}=    Get Api Ids And Names From Discover Response    ${discover_response}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        # Create Log Entry
+        ${request_body}=  Create Log Entry  ${register_user_info['aef_id']}  ${register_user_info_invoker['api_invoker_id']}  ${api_ids}  ${api_names}
+        ${resp}=    Post Request Capif
+        ...    /api-invocation-logs/v1/${register_user_info['aef_id']}/logs
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AEF_PROVIDER_USERNAME}
+
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    201    InvocationLog
+        ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_LOGGING_RESOURCE_REGEX}
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Create a log entry invalid aefId
+#    [Tags]    capif_api_logging_service-2
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    # Publish one api
+#    Publish Service Api    ${register_user_info}
+#
+#    #Register INVOKER
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    ${api_ids}   ${api_names}=    Get Api Ids And Names From Discover Response    ${discover_response}
+#
+#    # Create Log Entry
+#    ${request_body}=  Create Log Entry  ${register_user_info['aef_id']}  ${register_user_info_invoker['api_invoker_id']}  ${api_ids}  ${api_names}
+#    ${resp}=    Post Request Capif
+#    ...    /api-invocation-logs/v1/${AEF_ID_NOT_VALID}/logs
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404   ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Exposer not exist
+#    ...    cause=Exposer id not found
+#
+#
+#
+#Create a log entry invalid serviceApi
+#    [Tags]    capif_api_logging_service-3
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    # Publish one api
+#    Publish Service Api    ${register_user_info}
+#
+#    #Register INVOKER
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Create Log Entry
+#    ${request_body}=  Create Log Entry Bad Service  ${register_user_info['aef_id']}  ${register_user_info_invoker['api_invoker_id']}
+#    ${resp}=    Post Request Capif
+#    ...    /api-invocation-logs/v1/${register_user_info['aef_id']}/logs
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Service API not exist
+#
+#Create a log entry invalid apiInvokerId
+#    [Tags]    capif_api_logging_service-4
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    # Publish one api
+#    Publish Service Api    ${register_user_info}
+#
+#    #Register INVOKER
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    ${api_ids}   ${api_names}=    Get Api Ids And Names From Discover Response    ${discover_response}
+#
+#    # Create Log Entry
+#    ${request_body}=  Create Log Entry  ${register_user_info['aef_id']}  ${API_INVOKER_NOT_VALID}   ${api_ids}  ${api_names}
+#    ${resp}=    Post Request Capif
+#    ...    /api-invocation-logs/v1/${register_user_info['aef_id']}/logs
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker not exist
+#    ...    cause=Invoker id not found
+#
+#
+#Create a log entry different aef_id in body
+#    [Tags]    capif_api_logging_service-5
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    # Publish one api
+#    Publish Service Api    ${register_user_info}
+#
+#    #Register INVOKER
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    ${api_ids}   ${api_names}=    Get Api Ids And Names From Discover Response    ${discover_response}
+#
+#    # Create Log Entry
+#    ${request_body}=  Create Log Entry  ${AEF_ID_NOT_VALID}  ${register_user_info_invoker['api_invoker_id']}  ${api_ids}  ${api_names}
+#    ${resp}=    Post Request Capif
+#    ...    /api-invocation-logs/v1/${register_user_info['aef_id']}/logs
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=AEF id not matching in request and body
+#    ...    cause=Not identical AEF id
+

--- a/perf_tests/features/CAPIF Api Provider Management/__init__.robot
+++ b/perf_tests/features/CAPIF Api Provider Management/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_provider_management

--- a/perf_tests/features/CAPIF Api Provider Management/capif_api_provider_management.robot
+++ b/perf_tests/features/CAPIF Api Provider Management/capif_api_provider_management.robot
@@ -1,0 +1,284 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+Library         Process
+Library         Collections
+
+Test Setup      Reset Testing Environment
+
+
+*** Variables ***
+${API_PROVIDER_NOT_REGISTERED}      notValid
+
+
+*** Test Cases ***
+Register Api Provider
+    [Tags]    capif_api_provider_management-1
+    #Register Provider User An create Certificates for each function
+    ${register_user_info}=    Register User At Jwt Auth Provider
+    ...    username=${PROVIDER_USERNAME}    role=${PROVIDER_ROLE}
+
+    # Create provider Registration Body
+    ${apf_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['apf_username']}
+    ...    ${register_user_info['apf_csr_request']}
+    ...    APF
+    ${aef_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['aef_username']}
+    ...    ${register_user_info['aef_csr_request']}
+    ...    AEF
+    ${amf_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['amf_username']}
+    ...    ${register_user_info['amf_csr_request']}
+    ...    AMF
+    ${api_prov_funcs}=    Create List    ${apf_func_details}    ${aef_func_details}    ${amf_func_details}
+
+    ${request_body}=    Create Api Provider Enrolment Details Body
+    ...    ${register_user_info['access_token']}
+    ...    ${api_prov_funcs}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # Register Provider
+        ${resp}=    Post Request Capif
+        ...    /api-provider-management/v1/registrations
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    access_token=${register_user_info['access_token']}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    201    APIProviderEnrolmentDetails
+        ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_PROVIDER_RESOURCE_REGEX}
+
+        Set To Dictionary  # Upkeep for deletion
+        ...    ${register_user_info}
+        ...    resource_url=${resource_url}
+
+        FOR    ${prov}    IN    @{resp.json()['apiProvFuncs']}
+            Log Dictionary    ${prov}
+            Store In File    ${prov['apiProvFuncInfo']}.crt    ${prov['regInfo']['apiProvCert']}
+        END
+
+        # Delete Provider
+        ${delete}=    Delete Request Capif
+        ...    ${register_user_info['resource_url'].path}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AMF_PROVIDER_USERNAME}
+
+        # Check Results
+        Status Should Be    204    ${delete}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Register Api Provider Already registered
+#    [Tags]    capif_api_provider_management-2
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${resp}=    Post Request Capif
+#    ...    /api-provider-management/v1/registrations
+#    ...    json=${register_user_info['provider_enrollment_details']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    access_token=${register_user_info['access_token']}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    403    ProblemDetails
+#    ...    status=403
+#    ...    title=Forbidden
+#    ...    detail=Provider already registered
+#    ...    cause=Identical provider reg sec
+
+Update Registered Api Provider Performance
+    [Tags]    capif_api_provider_management-3
+    ${register_user_info}=    Provider Default Registration
+
+    ${request_body}=    Set Variable    ${register_user_info['provider_enrollment_details']}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        Set To Dictionary    ${request_body}    apiProvDomInfo=ROBOT_TESTING_MOD_${index}
+
+        ${resp}=    Put Request Capif
+        ...    ${register_user_info['resource_url'].path}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AMF_PROVIDER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    200    APIProviderEnrolmentDetails
+        ...    apiProvDomInfo=ROBOT_TESTING_MOD_${index}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Update Not Registered Api Provider
+#    [Tags]    capif_api_provider_management-4
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${request_body}=    Set Variable    ${register_user_info['provider_enrollment_details']}
+#
+#    ${resp}=    Put Request Capif
+#    ...    /api-provider-management/v1/registrations/${API_PROVIDER_NOT_REGISTERED}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AMF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    status=404
+#    ...    title=Not Found
+#    ...    detail=Not Exist Provider Enrolment Details
+#    ...    cause=Not found registrations to send this api provider details
+
+Partially Update Registered Api Provider Performance
+    [Tags]    capif_api_provider_management-5
+    ${register_user_info}=    Provider Default Registration
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${request_body}=    Create Api Provider Enrolment Details Patch Body    ROBOT_TESTING_MOD_${index}
+
+        ${resp}=    Patch Request Capif
+        ...    ${register_user_info['resource_url'].path}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AMF_PROVIDER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    200    APIProviderEnrolmentDetails
+        ...    apiProvDomInfo=ROBOT_TESTING_MOD_${index}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Partially Update Not Registered Api Provider
+#    [Tags]    capif_api_provider_management-6
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${request_body}=    Create Api Provider Enrolment Details Patch Body
+#
+#    ${resp}=    Patch Request Capif
+#    ...    /api-provider-management/v1/registrations/${API_PROVIDER_NOT_REGISTERED}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AMF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    status=404
+#    ...    title=Not Found
+#    ...    detail=Not Exist Provider Enrolment Details
+#    ...    cause=Not found registrations to send this api provider details
+
+Delete Registered Api Provider Performance
+    [Tags]    capif_api_provider_management-7
+
+    #Register Provider User An create Certificates for each function
+    ${register_user_info}=    Register User At Jwt Auth Provider
+    ...    username=${PROVIDER_USERNAME}    role=${PROVIDER_ROLE}
+
+    # Create provider Registration Body
+    ${apf_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['apf_username']}
+    ...    ${register_user_info['apf_csr_request']}
+    ...    APF
+    ${aef_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['aef_username']}
+    ...    ${register_user_info['aef_csr_request']}
+    ...    AEF
+    ${amf_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['amf_username']}
+    ...    ${register_user_info['amf_csr_request']}
+    ...    AMF
+    ${api_prov_funcs}=    Create List    ${apf_func_details}    ${aef_func_details}    ${amf_func_details}
+
+    ${request_body}=    Create Api Provider Enrolment Details Body
+    ...    ${register_user_info['access_token']}
+    ...    ${api_prov_funcs}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # Register Provider
+        ${resp}=    Post Request Capif
+        ...    /api-provider-management/v1/registrations
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    access_token=${register_user_info['access_token']}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    201    APIProviderEnrolmentDetails
+        ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_PROVIDER_RESOURCE_REGEX}
+
+        Set To Dictionary  # Upkeep for deletion
+        ...    ${register_user_info}
+        ...    resource_url=${resource_url}
+
+        FOR    ${prov}    IN    @{resp.json()['apiProvFuncs']}
+            Log Dictionary    ${prov}
+            Store In File    ${prov['apiProvFuncInfo']}.crt    ${prov['regInfo']['apiProvCert']}
+        END
+
+        # Delete Provider
+        ${delete}=    Delete Request Capif
+        ...    ${register_user_info['resource_url'].path}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AMF_PROVIDER_USERNAME}
+
+        # Check Results
+        Status Should Be    204    ${delete}
+
+        ${success}       ${average}      Handle Timing       ${delete.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Delete Not Registered Api Provider
+#    [Tags]    capif_api_provider_management-8
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /api-provider-management/v1/registrations/${API_PROVIDER_NOT_REGISTERED}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AMF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    status=404
+#    ...    title=Not Found
+#    ...    detail=Not Exist Provider Enrolment Details
+#    ...    cause=Not found registrations to send this api provider details

--- a/perf_tests/features/CAPIF Api Publish Service/__init__.robot
+++ b/perf_tests/features/CAPIF Api Publish Service/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_api_publish_service

--- a/perf_tests/features/CAPIF Api Publish Service/capif_api_publish_service.robot
+++ b/perf_tests/features/CAPIF Api Publish Service/capif_api_publish_service.robot
@@ -1,0 +1,374 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Resource        ../../resources/common/basicRequests.robot
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+
+Test Setup      Reset Testing Environment
+
+
+*** Variables ***
+${APF_ID_NOT_VALID}             apf-example
+${SERVICE_API_ID_NOT_VALID}     not-valid
+
+
+*** Test Cases ***
+Publish API by Authorised API Publisher
+    [Tags]    capif_api_publish_service-1
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    # Test
+    ${request_body}=    Create Service Api Description    service_1
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Post Request Capif
+        ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    201    ServiceAPIDescription
+        ...    apiName=service_1
+        Dictionary Should Contain Key    ${resp.json()}    apiId
+        ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_PUBLISH_RESOURCE_REGEX}
+
+        ${delete}=    Delete Request Capif
+        ...    ${resource_url.path}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Status Should Be    204    ${delete}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Publish API by NON Authorised API Publisher
+#    [Tags]    capif_api_publish_service-2
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${request_body}=    Create Service Api Description
+#    ${resp}=    Post Request Capif
+#    ...    /published-apis/v1/${APF_ID_NOT_VALID}/service-apis
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${APF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    status=401
+#    ...    title=Unauthorized
+#    ...    detail=Publisher not existing
+#    ...    cause=Publisher id not found
+
+Retrieve all APIs Published by Authorised apfId
+    [Tags]    capif_api_publish_service-3
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    # Register One Service
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    service_1
+    ${service_api_description_published_2}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    service_2
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # Retrieve Services published
+        ${resp}=    Get Request Capif
+        ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    ServiceAPIDescription
+
+        List Should Contain Value    ${resp.json()}    ${service_api_description_published_1}
+        List Should Contain Value    ${resp.json()}    ${service_api_description_published_2}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Retrieve all APIs Published by NON Authorised apfId
+#    [Tags]    capif_api_publish_service-4
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    # Retrieve Services published
+#    ${resp}=    Get Request Capif
+#    ...    /published-apis/v1/${APF_ID_NOT_VALID}/service-apis
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${APF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Publisher not existing
+#    ...    cause=Publisher id not found
+
+Retrieve single APIs Published by Authorised apfId
+    [Tags]    capif_api_publish_service-5
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    service_1
+
+    # Store apiId1
+    ${serviceApiId1}=    Set Variable    ${service_api_description_published_1['apiId']}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # Retrieve Services 1
+        ${resp}=    Get Request Capif
+        ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis/${serviceApiId1}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    ServiceAPIDescription
+        Dictionaries Should Be Equal    ${resp.json()}    ${service_api_description_published_1}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+Retrieve single APIs non Published by Authorised apfId
+    [Tags]    capif_api_publish_service-6
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Get Request Capif
+        ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis/${SERVICE_API_ID_NOT_VALID}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+        ...    title=Not Found
+        ...    status=404
+        ...    detail=Service API not found
+        ...    cause=No Service with specific credentials exists
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Retrieve single APIs Published by NON Authorised apfId
+#    [Tags]    capif_api_publish_service-7
+#    # Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    # Publish Service API
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info}
+#    ...    service_1
+#
+#    # Register INVOKER
+#    ${register_user_info_invoker}=    Invoker Default Onboarding
+#
+#    ${resp}=    Get Request Capif
+#    ...    ${resource_url.path}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=User not authorized
+#    ...    cause=Certificate not authorized
+
+Update API Published by Authorised apfId with valid serviceApiId
+    [Tags]    capif_api_publish_service-8
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info}
+    ...    service_1
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${request_body_modified}=    Create Service Api Description    service_1_modified_${index}
+        ${resp}=    Put Request Capif
+        ...    ${resource_url.path}
+        ...    json=${request_body_modified}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    ServiceAPIDescription
+        ...    apiName=service_1_modified_${index}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+
+#Update APIs Published by Authorised apfId with invalid serviceApiId
+#    [Tags]    capif_api_publish_service-9
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info}
+#    ...    service_1
+#
+#    ${request_body}=    Create Service Api Description    service_1_modified
+#    ${resp}=    Put Request Capif
+#    ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis/${SERVICE_API_ID_NOT_VALID}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${APF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Service API not existing
+#    ...    cause=Service API id not found
+#
+#Update APIs Published by NON Authorised apfId
+#    [Tags]    capif_api_publish_service-10
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info}
+#    ...    service_1
+#
+#    #Register INVOKER
+#    ${register_user_info_invoker}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Api Description    service_1_modified
+#    ${resp}=    Put Request Capif
+#    ...    ${resource_url.path}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=User not authorized
+#    ...    cause=Certificate not authorized
+#
+#    # Retrieve Service
+#    ${resp}=    Get Request Capif
+#    ...    ${resource_url.path}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${APF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    200    ServiceAPIDescription
+#    ...    apiName=service_1
+
+Delete API Published by Authorised apfId with valid serviceApiId
+    [Tags]    capif_api_publish_service-11
+    #Register APF
+    ${register_user_info}=    Provider Default Registration
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+        ...    ${register_user_info}
+        ...    first_service
+
+        ${resp}=    Delete Request Capif
+        ...    ${resource_url.path}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${APF_PROVIDER_USERNAME}
+
+        Status Should Be    204    ${resp}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Delete APIs Published by Authorised apfId with invalid serviceApiId
+#    [Tags]    capif_api_publish_service-12
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis/${SERVICE_API_ID_NOT_VALID}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${APF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Service API not existing
+#    ...    cause=Service API id not found
+#
+#Delete APIs Published by NON Authorised apfId
+#    [Tags]    capif_api_publish_service-13
+#    #Register APF
+#    ${register_user_info}=    Provider Default Registration
+#
+#    #Register INVOKER
+#    ${register_user_info_invoker}=    Invoker Default Onboarding
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /published-apis/v1/${register_user_info['apf_id']}/service-apis/${SERVICE_API_ID_NOT_VALID}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=User not authorized
+#    ...    cause=Certificate not authorized

--- a/perf_tests/features/CAPIF Security Api/__init__.robot
+++ b/perf_tests/features/CAPIF Security Api/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Force Tags    capif_security_api

--- a/perf_tests/features/CAPIF Security Api/capif_security_api.robot
+++ b/perf_tests/features/CAPIF Security Api/capif_security_api.robot
@@ -1,0 +1,1088 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Library         /opt/robot-tests/tests/libraries/bodyRequests.py
+Library         Collections
+Resource        /opt/robot-tests/tests/resources/common/basicRequests.robot
+Resource        ../../resources/common.resource
+Resource        ../../resources/performance.resource
+
+Test Setup      Reset Testing Environment
+
+
+*** Variables ***
+${APF_ID_NOT_VALID}             apf-example
+${SERVICE_API_ID_NOT_VALID}     not-valid
+${API_INVOKER_NOT_VALID}        not-valid
+${NOTIFICATION_DESTINATION}     http://robot.testing:1080
+
+
+*** Test Cases ***
+Create a security context for an API invoker Performance
+    [Tags]    capif_security_api-1
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Register APF
+    ${register_user_info_publisher}=    Provider Default Registration
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        # Create Security Context
+        ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+        ${resp}=    Put Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+        ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_SECURITY_RESOURCE_REGEX}
+
+        # Remove Security Context
+        ${delete}=    Delete Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AEF_PROVIDER_USERNAME}
+
+        Status Should Be    204    ${delete}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Create a security context for an API invoker with Provider role
+#    [Tags]    capif_security_api-2
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Register Provider
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    # Create Security Context
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be invoker
+
+#Create a security context for an API invoker with Provider entity role and invalid apiInvokerId
+#    [Tags]    capif_security_api-3
+#    # Register APF
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    # Create Security Context
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be invoker
+#
+#Create a security context for an API invoker with Invalid apiInvokerID
+#    [Tags]    capif_security_api-4
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker not found
+#    ...    cause=API Invoker not exists or invalid ID
+
+Retrieve the Security Context of an API Invoker Performance
+    [Tags]    capif_security_api-5
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+    ${resp}=    Put Request Capif
+    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+    ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_SECURITY_RESOURCE_REGEX}
+
+    ${service_security_context}=    Set Variable    ${resp.json()}
+
+    # Register APF
+    ${register_user_info_publisher}=    Provider Default Registration
+    # Retrieve Security context can setup by parameters if authenticationInfo and authorizationInfo are needed at response.
+    # ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}?authenticationInfo=true&authorizationInfo=true
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Get Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AEF_PROVIDER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    200    ServiceSecurity
+
+        ${service_security_context_filtered}=    Remove Keys From Object
+        ...    ${service_security_context}
+        ...    authenticationInfo
+        ...    authorizationInfo
+
+        Dictionaries Should Be Equal    ${resp.json()}    ${service_security_context_filtered}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Retrieve the Security Context of an API Invoker with invalid apiInvokerID
+#    [Tags]    capif_security_api-6
+#    # Register APF
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    ${resp}=    Get Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker not found
+#    ...    cause=API Invoker not exists or invalid ID
+
+#Retrieve the Security Context of an API Invoker with invalid apfId
+#    [Tags]    capif_security_api-7
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # We will request information using invoker user, that is not allowed
+#    ${resp}=    Get Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be aef
+
+Delete the Security Context of an API Invoker Delete
+    [Tags]    capif_security_api-8
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Register APF
+    ${register_user_info_publisher}=    Provider Default Registration
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+        ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+        ${resp}=    Put Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+
+        # Remove Security Context
+        ${resp}=    Delete Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AEF_PROVIDER_USERNAME}
+
+        Status Should Be    204    ${resp}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+
+#Delete the Security Context of an API Invoker with Invoker entity role
+#    [Tags]    capif_security_api-9
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Result
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be aef
+
+#Delete the Security Context of an API Invoker with Invoker entity role and invalid apiInvokerID
+#    [Tags]    capif_security_api-10
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Result
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be aef
+#
+#Delete the Security Context of an API Invoker with invalid apiInvokerID
+#    [Tags]    capif_security_api-11
+#    # Register Provider
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    ${resp}=    Delete Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Result
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker not found
+#    ...    cause=API Invoker not exists or invalid ID
+
+Update the Security Context of an API Invoker Performance
+    [Tags]    capif_security_api-12
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Register Provider
+    ${register_user_info_publisher}=    Provider Default Registration
+
+    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+    ${resp}=    Put Request Capif
+    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    # Check Results
+    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+
+    # Store Initial Security Context
+    #${security_context}=    Set Variable    ${resp.json()}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # Update Security Context
+        ${request_body}=    Create Service Security Body    http://robot.testing_${index}
+        ${resp}=    Post Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}/update
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    200    ServiceSecurity
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Update the Security Context of an API Invoker with Provider entity role
+#    [Tags]    capif_security_api-13
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    #Register Provider
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}/update
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be invoker
+
+#Update the Security Context of an API Invoker with AEF entity role and invalid apiInvokerId
+#    [Tags]    capif_security_api-14
+#    #Register Provider
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}/update
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be invoker
+#
+#Update the Security Context of an API Invoker with invalid apiInvokerID
+#    [Tags]    capif_security_api-15
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}/update
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Result
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker not found
+#    ...    cause=API Invoker not exists or invalid ID
+
+Revoke the authorization of the API invoker for APIs Performance
+    [Tags]    capif_security_api-16
+    # Register APF
+    ${register_user_info_provider}=    Provider Default Registration
+    ${api_name}=    Set Variable    service_1
+
+    # Register One Service
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info_provider}
+    ...    ${api_name}
+
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Test
+    ${discover_response}=    Get Request Capif
+    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}&aef-id=${register_user_info_provider['aef_id']}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+
+    ${api_ids}=    Get Api Ids From Discover Response    ${discover_response}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        # create Security Context
+        ${request_body}=    Create Service Security From Discover Response
+        ...    http://${CAPIF_HOSTNAME}:${CAPIF_HTTP_PORT}/test
+        ...    ${discover_response}
+        ${resp}=    Put Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+
+        # Revoke Security Context by Provider
+        ${request_body}=    Create Security Notification Body
+        ...    ${register_user_info_invoker['api_invoker_id']}
+        ...    ${api_ids}
+        ${resp}=    Post Request Capif
+        ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}/delete
+        ...    json=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${AEF_PROVIDER_USERNAME}
+
+        # Check Results
+        Status Should Be    204    ${resp}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Revoke the authorization of the API invoker for APIs without valid apfID.
+#    [Tags]    capif_security_api-17
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    ${security_context}=    Set Variable    ${resp.json()}
+#
+#    # Register Provider
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    # Revoke Security Context by Invoker
+#    ${request_body}=    Create Security Notification Body    ${register_user_info_invoker['api_invoker_id']}    1234
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}/delete
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    ProblemDetails
+#    ...    title=Unauthorized
+#    ...    status=401
+#    ...    detail=Role not authorized for this API route
+#    ...    cause=User role must be aef
+#
+#    ${resp}=    Get Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    200    ServiceSecurity
+#    ${security_context_filtered}=    Remove Keys From Object
+#    ...    ${security_context}
+#    ...    authenticationInfo
+#    ...    authorizationInfo
+#    Dictionaries Should Be Equal    ${resp.json()}    ${security_context_filtered}
+#
+#Revoke the authorization of the API invoker for APIs with invalid apiInvokerId
+#    [Tags]    capif_security_api-18
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    ${request_body}=    Create Service Security Body    ${NOTIFICATION_DESTINATION}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    ${security_context}=    Set Variable    ${resp.json()}
+#
+#    #Register Provider
+#    ${register_user_info_publisher}=    Provider Default Registration
+#
+#    ${request_body}=    Create Security Notification Body    ${API_INVOKER_NOT_VALID}    1234
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${API_INVOKER_NOT_VALID}/delete
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Invoker not found
+#    ...    cause=API Invoker not exists or invalid ID
+#
+#    ${resp}=    Get Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}?authenticationInfo=true&authorizationInfo=true
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    200    ServiceSecurity
+#    Dictionaries Should Be Equal    ${resp.json()}    ${security_context}
+
+Retrieve access token Performance
+    [Tags]    capif_security_api-19
+    # Register APF
+    ${register_user_info_provider}=    Provider Default Registration
+    ${api_name}=    Set Variable    service_1
+
+    # Register One Service
+    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+    ...    ${register_user_info_provider}
+    ...    ${api_name}
+
+    # Default Invoker Registration and Onboarding
+    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+
+    # Test
+    ${discover_response}=    Get Request Capif
+    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+
+    # create Security Context
+    ${request_body}=    Create Service Security From Discover Response
+    ...    ${NOTIFICATION_DESTINATION}
+    ...    ${discover_response}
+    ${resp}=    Put Request Capif
+    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${INVOKER_USERNAME}
+
+    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+
+    # Retrieve Token from CCF
+    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+    ${request_body}=    Create Access Token Req Body    ${register_user_info_invoker['api_invoker_id']}    ${scope}
+
+    ${success}=     Set Variable    ${0}
+    ${average}=     Set Variable    ${0}
+
+    FOR     ${index}    IN RANGE    ${ITERATIONS}
+        Log To Console      \nIteration: ${index}
+
+        ${resp}=    Post Request Capif
+        ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+        ...    data=${request_body}
+        ...    server=${CAPIF_HTTPS_URL}
+        ...    verify=ca.crt
+        ...    username=${INVOKER_USERNAME}
+
+        # Check Results
+        Check Response Variable Type And Values    ${resp}    200    AccessTokenRsp
+        ...    token_type=Bearer
+
+        Should Not Be Empty    ${resp.json()['access_token']}
+
+        ${success}       ${average}      Handle Timing       ${resp.elapsed}     ${index}    ${average}      ${success}
+    END
+
+    Handle End Results      ${success}      ${average}
+
+#Retrieve access token by Provider
+#    [Tags]    capif_security_api-20
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${request_body}=    Create Access Token Req Body    ${register_user_info_invoker['api_invoker_id']}    ${scope}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    AccessTokenErr
+#    ...    error=unauthorized_client
+#    ...    error_description=Role not authorized for this API route
+
+#Retrieve access token by Provider with invalid apiInvokerId
+#    [Tags]    capif_security_api-21
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${request_body}=    Create Access Token Req Body    ${register_user_info_invoker['api_invoker_id']}    ${scope}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${API_INVOKER_NOT_VALID}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${AEF_PROVIDER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    401    AccessTokenErr
+#    ...    error=unauthorized_client
+#    ...    error_description=Role not authorized for this API route
+#
+#Retrieve access token with invalid apiInvokerId
+#    [Tags]    capif_security_api-22
+#    # Default Invoker Registration and Onboarding
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${request_body}=    Create Access Token Req Body    ${register_user_info_invoker['api_invoker_id']}    ${scope}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${API_INVOKER_NOT_VALID}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    404    ProblemDetails29571
+#    ...    title=Not Found
+#    ...    status=404
+#    ...    detail=Security context not found
+#    ...    cause=API Invoker has no security context
+#
+#Retrieve access token with invalid client_id
+#    [Tags]    capif_security_api-23
+#    # Default Invoker Registration and Onboarding
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${request_body}=    Create Access Token Req Body    ${API_INVOKER_NOT_VALID}    ${scope}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    400    AccessTokenErr
+#    ...    error=invalid_client
+#    ...    error_description=Client Id not found
+#
+#Retrieve access token with unsupported grant_type
+#    [Tags]    capif_security_api-24
+#    # Default Invoker Registration and Onboarding
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${grant_type}=    Set Variable    not_valid
+#    ${request_body}=    Create Access Token Req Body
+#    ...    ${register_user_info_invoker['api_invoker_id']}
+#    ...    ${scope}
+#    ...    grant_type=${grant_type}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values
+#    ...    ${resp}
+#    ...    400
+#    ...    AccessTokenErr
+#    ...    error=unsupported_grant_type
+#    ...    error_description=Invalid value for `grant_type` \\(${grant_type}\\), must be one of \\['client_credentials'\\] - 'grant_type'
+#
+#Retrieve access token with invalid scope
+#    [Tags]    capif_security_api-25
+#    # Default Invoker Registration and Onboarding
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${request_body}=    Create Access Token Req Body
+#    ...    ${register_user_info_invoker['api_invoker_id']}
+#    ...    "not-valid-scope"
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    400    AccessTokenErr
+#    ...    error=invalid_scope
+#    ...    error_description=The first characters must be '3gpp'
+#
+#Retrieve access token with invalid aefid at scope
+#    [Tags]    capif_security_api-26
+#    # Default Invoker Registration and Onboarding
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${scope}=    Create Scope    ${register_user_info_provider['aef_id']}    ${api_name}
+#    ${request_body}=    Create Access Token Req Body
+#    ...    ${register_user_info_invoker['api_invoker_id']}
+#    ...    3gpp#1234:${api_name}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    400    AccessTokenErr
+#    ...    error=invalid_scope
+#    ...    error_description=One of aef_id not belongs of your security context
+#
+#Retrieve access token with invalid apiName at scope
+#    [Tags]    capif_security_api-27
+#    # Default Invoker Registration and Onboarding
+#    # Register APF
+#    ${register_user_info_provider}=    Provider Default Registration
+#    ${api_name}=    Set Variable    service_1
+#
+#    # Register One Service
+#    ${service_api_description_published_1}    ${resource_url}    ${request_body}=    Publish Service Api
+#    ...    ${register_user_info_provider}
+#    ...    ${api_name}
+#
+#    # Default Invoker Registration and Onboarding
+#    ${register_user_info_invoker}    ${url}    ${request_body}=    Invoker Default Onboarding
+#
+#    # Test
+#    ${discover_response}=    Get Request Capif
+#    ...    ${DISCOVER_URL}${register_user_info_invoker['api_invoker_id']}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${discover_response}    200    DiscoveredAPIs
+#
+#    # create Security Context
+#    ${request_body}=    Create Service Security From Discover Response
+#    ...    ${NOTIFICATION_DESTINATION}
+#    ...    ${discover_response}
+#    ${resp}=    Put Request Capif
+#    ...    /capif-security/v1/trustedInvokers/${register_user_info_invoker['api_invoker_id']}
+#    ...    json=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    Check Response Variable Type And Values    ${resp}    201    ServiceSecurity
+#
+#    # Retrieve Token from CCF
+#    ${not_valid_api_name}=    Set Variable    not-valid
+#    ${request_body}=    Create Access Token Req Body
+#    ...    ${register_user_info_invoker['api_invoker_id']}
+#    ...    3gpp#${register_user_info_provider['aef_id']}:${not_valid_api_name}
+#    ${resp}=    Post Request Capif
+#    ...    /capif-security/v1/securities/${register_user_info_invoker['api_invoker_id']}/token
+#    ...    data=${request_body}
+#    ...    server=${CAPIF_HTTPS_URL}
+#    ...    verify=ca.crt
+#    ...    username=${INVOKER_USERNAME}
+#
+#    # Check Results
+#    Check Response Variable Type And Values    ${resp}    400    AccessTokenErr
+#    ...    error=invalid_scope
+#    ...    error_description=One of the api names does not exist or is not associated with the aef id provided

--- a/perf_tests/features/__init__.robot
+++ b/perf_tests/features/__init__.robot
@@ -1,0 +1,46 @@
+*** Settings ***
+Resource        /opt/robot-tests/tests/resources/common.resource
+Resource    ../resources/common.resource
+
+Suite Setup     Prepare environment
+# Suite Teardown  Reset Testing Environment
+
+Force Tags      all
+
+
+*** Keywords ***
+Prepare environment
+    Log    ${CAPIF_HOSTNAME}
+    Log    "${CAPIF_HTTP_PORT}"
+    Log    "${CAPIF_HTTPS_PORT}"
+
+    Set Global Variable    ${CAPIF_HTTP_URL}    http://${CAPIF_HOSTNAME}/
+    IF    "${CAPIF_HTTP_PORT}" != ""
+        Set Global Variable    ${CAPIF_HTTP_URL}    http://${CAPIF_HOSTNAME}:${CAPIF_HTTP_PORT}/
+    END
+
+    Set Global Variable    ${CAPIF_HTTPS_URL}    https://${CAPIF_HOSTNAME}/
+    IF    "${CAPIF_HTTPS_PORT}" != ""
+        Set Global Variable    ${CAPIF_HTTPS_URL}    https://${CAPIF_HOSTNAME}:${CAPIF_HTTPS_PORT}/
+    END
+
+    ${status}    ${CAPIF_IP}=    Run Keyword And Ignore Error    Get Ip From Hostname    ${CAPIF_HOSTNAME}
+
+    IF    "${status}" == "PASS"
+        Log    We will use a remote deployment
+        Log    ${CAPIF_IP}
+    ELSE
+        Log    We will use a local deployment
+        Add Dns To Hosts    127.0.0.1    ${CAPIF_HOSTNAME}
+    END
+    # Obtain ca root certificate
+    Retrieve Ca Root
+
+    Reset Testing Environment
+
+Retrieve Ca Root
+    [Documentation]    This keyword retrieve ca.root from CAPIF and store it at ca.crt in order to use at TLS communications
+    ${resp}=    Get Request Capif    /ca-root    server=${CAPIF_HTTP_URL}
+    Status Should Be    201    ${resp}
+    Log    ${resp.json()['certificate']}
+    Store In File    ca.crt    ${resp.json()['certificate']}

--- a/perf_tests/libraries/api_events/bodyRequests.py
+++ b/perf_tests/libraries/api_events/bodyRequests.py
@@ -1,0 +1,32 @@
+def create_events_subscription():
+    return {
+        "eventFilters": [
+            {
+                "aefIds": ["aefIds", "aefIds"],
+                "apiIds": ["apiIds", "apiIds"],
+                "apiInvokerIds": ["apiInvokerIds", "apiInvokerIds"]
+            },
+            {
+                "aefIds": ["aefIds", "aefIds"],
+                "apiIds": ["apiIds", "apiIds"],
+                "apiInvokerIds": ["apiInvokerIds", "apiInvokerIds"]
+            }
+        ],
+        "eventReq": {
+            "grpRepTime": 5,
+            "immRep": True,
+            "maxReportNbr": 0,
+            "monDur": "2000-01-23T04:56:07+00:00",
+            "partitionCriteria": ["TAC", "GEOAREA"],
+            "repPeriod": 6,
+            "sampRatio": 15
+        },
+        "events": ["SERVICE_API_AVAILABLE", "API_INVOKER_ONBOARDED"],
+        "notificationDestination": "http://robot.testing",
+        "requestTestNotification": True,
+        "supportedFeatures": "aaa",
+        "websockNotifConfig": {
+            "requestWebsocketUri": True,
+            "websocketUri": "websocketUri"
+        }
+    }

--- a/perf_tests/libraries/api_invoker_management/bodyRequests.py
+++ b/perf_tests/libraries/api_invoker_management/bodyRequests.py
@@ -1,0 +1,20 @@
+def create_onboarding_notification_body(notification_destination="https://host.docker.internal/netapp_callback", api_invoker_public_key="ApiInvokerPublicKey",api_invoker_information='ROBOT_TESTING', api_invoker_id=None):
+    data = {
+        "notificationDestination": notification_destination,
+        "supportedFeatures": "fffffff",
+        "apiInvokerInformation": api_invoker_information,
+        "websockNotifConfig": {
+            "requestWebsocketUri": True,
+            "websocketUri": "websocketUri"
+        },
+        "onboardingInformation": {
+            "apiInvokerPublicKey": api_invoker_public_key.decode("utf-8"),
+            "onboardingSecret": "onboardingSecret",
+            "apiInvokerCertificate": "apiInvokerCertificate"
+        },
+        "requestTestNotification": True
+    }
+    if api_invoker_id != None:
+        data['apiInvokerId'] = api_invoker_id
+
+    return (data)

--- a/perf_tests/libraries/api_logging_service/bodyRequests.py
+++ b/perf_tests/libraries/api_logging_service/bodyRequests.py
@@ -1,0 +1,133 @@
+def create_log_entry(aefId=None, apiInvokerId=None, apiId=None, apiName=None):
+    data = {
+    "aefId": aefId,
+    "apiInvokerId": apiInvokerId,
+    "logs": [
+        {
+        "apiId": apiId[0],
+        "apiName": apiName[0],
+        "apiVersion": "v1",
+        "resourceName": "string",
+        "uri": "http://resource/endpoint",
+        "protocol": "HTTP_1_1",
+        "operation": "GET",
+        "result": "string",
+        "invocationTime": "2023-03-30T10:30:21.408Z",
+        "invocationLatency": 0,
+        "inputParameters": "string",
+        "outputParameters": "string",
+        "srcInterface": {
+            "ipv4Addr": "192.168.1.1",
+            "fqdn": "string",
+            "port": 65535,
+            "apiPrefix": "string",
+            "securityMethods": [
+            "PSK",
+            "string"
+            ]
+        },
+        "destInterface": {
+            "ipv4Addr": "192.168.1.23",
+            "fqdn": "string",
+            "port": 65535,
+            "apiPrefix": "string",
+            "securityMethods": [
+            "PSK",
+            "string"
+            ]
+        },
+        "fwdInterface": "string"
+        },
+        {
+        "apiId": apiId[0],
+        "apiName": apiName[0],
+        "apiVersion": "v2",
+        "resourceName": "string",
+        "uri": "http://resource/endpoint",
+        "protocol": "HTTP_1_1",
+        "operation": "GET",
+        "result": "string",
+        "invocationTime": "2023-03-30T10:30:21.408Z",
+        "invocationLatency": 0,
+        "inputParameters": "string",
+        "outputParameters": "string",
+        "srcInterface": {
+            "ipv4Addr": "192.168.1.1",
+            "fqdn": "string",
+            "port": 65535,
+            "apiPrefix": "string",
+            "securityMethods": [
+            "PSK",
+            "string"
+            ]
+        },
+        "destInterface": {
+            "ipv4Addr": "192.168.1.23",
+            "fqdn": "string",
+            "port": 65535,
+            "apiPrefix": "string",
+            "securityMethods": [
+            "PSK",
+            "string"
+            ]
+        },
+        "fwdInterface": "string"
+        }
+    ],
+    "supportedFeatures": "ffff"
+    }
+    return data 
+
+def create_log_entry_bad_service(aefId=None, apiInvokerId=None):
+    data = {
+    "aefId": aefId,
+    "apiInvokerId": apiInvokerId,
+    "logs": [
+        {
+        "apiId": "not-exist",
+        "apiName": "not-exist",
+        "apiVersion": "string",
+        "resourceName": "string",
+        "uri": "string",
+        "protocol": "HTTP_1_1",
+        "operation": "GET",
+        "result": "string",
+        "invocationTime": "2023-03-30T10:30:21.408Z",
+        "invocationLatency": 0,
+        "inputParameters": "string",
+        "outputParameters": "string",
+        "srcInterface": {
+            "ipv4Addr": "192.168.1.1",
+            "fqdn": "string",
+            "port": 65535,
+            "apiPrefix": "string",
+            "securityMethods": [
+            "PSK",
+            "string"
+            ]
+        },
+        "destInterface": {
+            "ipv4Addr": "192.168.1.23",
+            "fqdn": "string",
+            "port": 65535,
+            "apiPrefix": "string",
+            "securityMethods": [
+            "PSK",
+            "string"
+            ]
+        },
+        "fwdInterface": "string"
+        }
+    ],
+    "supportedFeatures": "ffff"
+    }
+    return data 
+
+def get_api_ids_and_names_from_discover_response(discover_response):
+    api_ids=[]
+    api_names=[]
+    service_api_descriptions = discover_response.json()['serviceAPIDescriptions']
+    for service_api_description in service_api_descriptions:
+        api_ids.append(service_api_description['apiId'])
+        api_names.append(service_api_description['apiName'])
+    return api_ids, api_names

--- a/perf_tests/libraries/api_provider_management/bodyRequests.py
+++ b/perf_tests/libraries/api_provider_management/bodyRequests.py
@@ -1,0 +1,41 @@
+def create_api_provider_enrolment_details_body(regSec, api_prov_funcs, apiProvDomInfo="ROBOT_TESTING"):
+    data = {
+        "regSec": regSec,
+        "apiProvFuncs": api_prov_funcs,
+        "apiProvDomInfo": apiProvDomInfo,
+        "suppFeat": "fffffff",
+        "failReason": "string"
+    }
+
+    return (data)
+
+
+def create_api_provider_function_details(username, public_key, role):
+    data = {
+        "regInfo": {
+            "apiProvPubKey": public_key.decode("utf-8"),
+        },
+        "apiProvFuncRole": role,
+        "apiProvFuncInfo": username
+
+    }
+    return data
+
+
+def create_api_provider_enrolment_details_patch_body(apiProvDomInfo="ROBOT_TESTING"):
+    data = {
+        "apiProvFuncs": [
+            {
+                "apiProvFuncId": "PATCH",
+                "regInfo": {
+                    "apiProvPubKey": "PATCH",
+                    "apiProvCert": "PATCH"
+                },
+                "apiProvFuncRole": "AEF",
+                "apiProvFuncInfo": "PATCH"
+            }
+        ],
+        "apiProvDomInfo": apiProvDomInfo,
+    }
+
+    return (data)

--- a/perf_tests/libraries/api_publish_service/bodyRequests.py
+++ b/perf_tests/libraries/api_publish_service/bodyRequests.py
@@ -1,0 +1,68 @@
+def create_service_api_description(api_name="service_1",aef_id="aef_id"):
+    return {
+        "apiName": api_name,
+        "aefProfiles": [
+            {
+                "aefId": aef_id,
+                "versions": [
+                    {
+                        "apiVersion": "v1",
+                        "expiry": "2021-11-30T10:32:02.004000Z",
+                        "resources": [
+                            {
+                                "resourceName": "string",
+                                "commType": "REQUEST_RESPONSE",
+                                "uri": "string",
+                                "custOpName": "string",
+                                "operations": [
+                                    "GET"
+                                ],
+                                "description": "string"
+                            }
+                        ],
+                        "custOperations": [
+                            {
+                                "commType": "REQUEST_RESPONSE",
+                                "custOpName": "string",
+                                "operations": [
+                                    "GET"
+                                ],
+                                "description": "string"
+                            }
+                        ]
+                    }
+                ],
+                "protocol": "HTTP_1_1",
+                "dataFormat": "JSON",
+                "securityMethods": ["PSK"],
+                "interfaceDescriptions": [
+                    {
+                        "ipv4Addr": "string",
+                        "port": 65535,
+                        "securityMethods": ["PSK"]
+                    },
+                    {
+                        "ipv4Addr": "string",
+                        "port": 65535,
+                        "securityMethods": ["PSK"]
+                    }
+                ]
+            }
+        ],
+        "description": "ROBOT_TESTING",
+        "supportedFeatures": "fffff",
+        "shareableInfo": {
+            "isShareable": True,
+            "capifProvDoms": [
+                "string"
+            ]
+        },
+        "serviceAPICategory": "string",
+        "apiSuppFeats": "fffff",
+        "pubApiPath": {
+            "ccfIds": [
+                "string"
+            ]
+        },
+        "ccfId": "string"
+    }

--- a/perf_tests/libraries/bodyRequests.py
+++ b/perf_tests/libraries/bodyRequests.py
@@ -1,0 +1,8 @@
+from common.bodyRequests import *
+from api_invoker_management.bodyRequests import *
+from api_logging_service.bodyRequests import *
+from api_publish_service.bodyRequests import *
+from api_events.bodyRequests import *
+from security_api.bodyRequests import *
+from api_provider_management.bodyRequests import *
+

--- a/perf_tests/libraries/common/bodyRequests.py
+++ b/perf_tests/libraries/common/bodyRequests.py
@@ -1,0 +1,125 @@
+from operator import contains
+import re
+import json
+from xmlrpc.client import boolean
+import rfc3987
+
+f = open('/opt/robot-tests/tests/libraries/common/types.json')
+capif_types = json.load(f)
+
+
+def check_variable(input, data_type):
+    print(input)
+    print(type(input))
+    print(data_type)
+    if isinstance(input, list):
+        for one in input:
+            check_variable(one, data_type)
+            return True
+    if data_type == "string":
+        if isinstance(input, str):
+            return True
+        else:
+            raise Exception("variable is not string type")
+    elif data_type == "integer":
+        if isinstance(input, int):
+            return True
+        else:
+            raise Exception("variable is not integer type")
+    elif data_type == "boolean":
+        if isinstance(input, boolean):
+            return True
+        else:
+            raise Exception("variable is not integer type")
+    elif data_type == "URI":
+        check_uri(input,data_type)
+        return True
+    elif data_type == "URI_reference":
+        check_uri(input, data_type)
+        return True
+    elif data_type not in capif_types.keys():
+        raise Exception("ERROR, type " + data_type +
+                        " is not present in types file")
+    if "Check" in capif_types[data_type].keys():
+        if not capif_types[data_type]["Check"]:
+            return True
+    if "enum" in capif_types[data_type].keys():
+        if input in capif_types[data_type]["enum"]:
+            print("value (" + input + ") is present at enum (" +
+                  ','.join(capif_types[data_type]["enum"]) + ")")
+            return True
+        else:
+            raise Exception("value (" + input + ") is not present at enum (" +
+                            ','.join(capif_types[data_type]["enum"]) + ")")
+    if "regex" in capif_types[data_type].keys():
+        check_regex(input, capif_types[data_type]["regex"])
+        return True
+
+    # Check Structure
+    all_attributes = check_attributes_dict(input, data_type)
+
+    print(all_attributes)
+
+    print('Check Variable type')
+    # Check Variable type
+    for key in input.keys():
+        print(key)
+        check_variable(input[key], all_attributes[key])
+
+
+def check_attributes_dict(body, data_type):
+    mandatory_attributes = capif_types[data_type]["mandatory_attributes"]
+    optional_parameters = capif_types[data_type]["optional_attributes"]
+    all_attributes = mandatory_attributes | optional_parameters
+    # Check if body has not allowed attributes
+
+    for body_key in body.keys():
+        if body_key not in all_attributes.keys():
+            raise Exception('Attribute "' + body_key +
+                            '" is not present as a mandatory or optional key (' + ','.join(all_attributes.keys()) + ')')
+
+    if mandatory_attributes:
+        for mandatory_key in mandatory_attributes.keys():
+            if mandatory_key not in body.keys():
+                raise Exception('Mandatory Attribute "' + mandatory_key +
+                                '" is not present at body under check')
+
+    if 'oneOf' in capif_types[data_type].keys():
+        one_of = capif_types[data_type]["oneOf"]
+        count = 0
+        for body_key in body.keys():
+            if body_key in one_of:
+                count = count+1
+
+        if count == 0:
+            raise Exception('Mandatory oneOf [' + ','.join(one_of) +
+                            '] is not present at body (' + ','.join(body.keys()) + ')')
+        elif count > 1:
+            raise Exception('More than one oneOf [' + ','.join(
+                one_of) + '] is present at body (' + ','.join(body.keys()) + ')')
+
+    return all_attributes
+
+
+def sign_csr_body(username, public_key):
+    data = {
+        "csr":  public_key.decode("utf-8"),
+        "mode":  "client",
+        "filename": username
+    }
+    return data
+
+
+def check_uri(input,rule):
+    if rfc3987.match(input, rule=rule) is not None:
+        return input
+    else:
+        raise Exception(rule + " is not accomplish rfc3986 rule ("+input+")")
+
+def check_regex(input, regex):
+    matched = re.match(regex, input)
+    is_match = bool(matched)
+    if is_match:
+        print("Regex match")
+    else:
+        raise Exception("Input(" + input + ") not match regex (" + regex + ")")

--- a/perf_tests/libraries/common/types.json
+++ b/perf_tests/libraries/common/types.json
@@ -1,0 +1,582 @@
+{
+  "ProblemDetails": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "type": "URI",
+      "title": "string",
+      "status": "integer",
+      "detail": "string",
+      "instance": "URI",
+      "cause": "string",
+      "invalidParams": "InvalidParam",
+      "supportedFeatures": "SupportedFeatures"
+    }
+  },
+  "ProblemDetails29571": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "type": "URI",
+      "title": "string",
+      "status": "integer",
+      "detail": "string",
+      "instance": "URI",
+      "cause": "string",
+      "invalidParams": "InvalidParam",
+      "supportedFeatures": "SupportedFeatures",
+      "accessTokenError": "AccessTokenErr",
+      "accessTokenRequest": "AccessTokenReq29571",
+      "nrfId": "NrfId"
+    }
+  },
+  "NrfId": {
+    "regex": "^([0-9A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?\\.)+[A-Za-z]{2,63}\\.?$"
+  },
+  "InvalidParam": {
+    "mandatory_attributes": {
+      "param": "string"
+    },
+    "optional_attributes": {
+      "reason": "string"
+    }
+  },
+  "APIInvokerEnrolmentDetails": {
+    "mandatory_attributes": {
+      "apiInvokerId": "string",
+      "onboardingInformation": "OnboardingInformation",
+      "notificationDestination": "URI"
+    },
+    "optional_attributes": {
+      "requestTestNotification": "boolean",
+      "websockNotifConfig": "WebsockNotifConfig",
+      "apiList": "ServiceAPIDescription",
+      "apiInvokerInformation": "string",
+      "supportedFeatures": "SupportedFeatures"
+    }
+  },
+  "OnboardingInformation": {
+    "mandatory_attributes": {
+      "apiInvokerPublicKey": "string"
+    },
+    "optional_attributes": {
+      "apiInvokerCertificate": "string",
+      "onboardingSecret": "string"
+    }
+  },
+  "WebsockNotifConfig": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "websocketUri": "URI_reference",
+      "requestWebsocketUri": "boolean"
+    }
+  },
+  "ServiceAPIDescription": {
+    "mandatory_attributes": {
+      "apiName": "string"
+    },
+    "optional_attributes": {
+      "apiId": "string",
+      "aefProfiles": "AefProfile",
+      "description": "string",
+      "supportedFeatures": "SupportedFeatures",
+      "shareableInfo": "ShareableInformation",
+      "serviceAPICategory": "string",
+      "apiSuppFeats": "SupportedFeatures",
+      "pubApiPath": "PublishedApiPath",
+      "ccfId": "string"
+    }
+  },
+  "AefProfile": {
+    "mandatory_attributes": {
+      "aefId": "string",
+      "versions": "Version"
+    },
+    "optional_attributes": {
+      "protocol": "Protocol",
+      "dataFormat": "DataFormat",
+      "securityMethods": "SecurityMethod",
+      "domainName": "string",
+      "interfaceDescriptions": "InterfaceDescription",
+      "aefLocation": "AefLocation"
+    },
+    "oneOf": ["interfaceDescriptions", "domainName"]
+  },
+  "Version": {
+    "mandatory_attributes": {
+      "apiVersion": "string"
+    },
+    "optional_attributes": {
+      "expiry": "string",
+      "resources": "Resource",
+      "custOperations": "CustomOperation"
+    }
+  },
+  "Resource": {
+    "mandatory_attributes": {
+      "resourceName": "string",
+      "commType": "CommunicationType",
+      "uri": "string"
+    },
+    "optional_attributes": {
+      "custOpName": "string",
+      "operations": "Operation",
+      "description": "string"
+    }
+  },
+  "CommunicationType": {
+    "enum": ["REQUEST_RESPONSE", "SUBSCRIBE_NOTIFY"]
+  },
+  "Operation": {
+    "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+  },
+  "CustomOperation": {
+    "mandatory_attributes": {
+      "commType": "CommunicationType",
+      "custOpName": "string"
+    },
+    "optional_attributes": {
+      "operations": "Operation",
+      "description": "string"
+    }
+  },
+  "Protocol": {
+    "enum": ["HTTP_1_1", "HTTP_2"]
+  },
+  "DataFormat": {
+    "enum": ["JSON"]
+  },
+  "SecurityMethod": {
+    "enum": ["PSK", "PKI", "OAUTH"]
+  },
+  "InterfaceDescription": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "ipv4Addr": "string",
+      "ipv6Addr": "string",
+      "port": "integer",
+      "securityMethods": "SecurityMethod"
+    },
+    "oneOf": ["ipv4Addr", "ipv6Addr"]
+  },
+  "AefLocation": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "civicAddr": "CivicAddress",
+      "geoArea": "GeographicArea",
+      "dcId": "string"
+    }
+  },
+  "CivicAddress": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "country": "string",
+      "A1": "string",
+      "A2": "string",
+      "A3": "string",
+      "A4": "string",
+      "A5": "string",
+      "A6": "string",
+      "PRD": "string",
+      "POD": "string",
+      "STS": "string",
+      "HNO": "string",
+      "HNS": "string",
+      "LMK": "string",
+      "LOC": "string",
+      "NAM": "string",
+      "PC": "string",
+      "BLD": "string",
+      "UNIT": "string",
+      "FLR": "string",
+      "ROOM": "string",
+      "PLC": "string",
+      "PCN": "string",
+      "POBOX": "string",
+      "ADDCODE": "string",
+      "SEAT": "string",
+      "RD": "string",
+      "RDSEC": "string",
+      "RDBR": "string",
+      "RDSUBBR": "string",
+      "PRM": "string",
+      "POM": "string",
+      "usageRules": "string",
+      "method": "string",
+      "providedBy": "string"
+    }
+  },
+  "GeographicArea": {
+    "Check": false
+  },
+  "ShareableInformation": {
+    "mandatory_attributes": {
+      "isShareable": "boolean"
+    },
+    "optional_attributes": {
+      "capifProvDoms": "string"
+    }
+  },
+  "PublishedApiPath": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "ccfIds": "string"
+    }
+  },
+  "EventSubscription": {
+    "mandatory_attributes": {
+      "events": "CAPIFEvent",
+      "notificationDestination": "URI"
+    },
+    "optional_attributes": {
+      "eventFilters": "CAPIFEventFilter",
+      "eventReq": "ReportingInformation",
+      "requestTestNotification": "boolean",
+      "websockNotifConfig": "WebsockNotifConfig",
+      "supportedFeatures": "SupportedFeatures"
+    }
+  },
+  "CAPIFEvent": {
+    "enum": [
+      "SERVICE_API_AVAILABLE",
+      "SERVICE_API_UNAVAILABLE",
+      "SERVICE_API_UPDATE",
+      "API_INVOKER_ONBOARDED",
+      "API_INVOKER_OFFBOARDED",
+      "SERVICE_API_INVOCATION_SUCCESS",
+      "SERVICE_API_INVOCATION_FAILURE",
+      "ACCESS_CONTROL_POLICY_UPDATE",
+      "ACCESS_CONTROL_POLICY_UNAVAILABLE",
+      "API_INVOKER_AUTHORIZATION_REVOKED",
+      "API_INVOKER_UPDATED",
+      "API_TOPOLOGY_HIDING_CREATED",
+      "API_TOPOLOGY_HIDING_REVOKED"
+    ]
+  },
+  "CAPIFEventFilter": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "apiIds": "string",
+      "apiInvokerIds": "string",
+      "aefIds": "string"
+    }
+  },
+  "ReportingInformation": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "immRep": "boolean",
+      "notifMethod": "NotificationMethod",
+      "maxReportNbr": "integer",
+      "monDur": "string",
+      "repPeriod": "integer",
+      "sampRatio": "integer",
+      "partitionCriteria": "PartitioningCriteria",
+      "grpRepTime": "integer",
+      "notifFlag": "NotificationFlag"
+    }
+  },
+  "NotificationMethod": {
+    "enum": ["PERIODIC", "ONE_TIME", "ON_EVENT_DETECTION"]
+  },
+  "PartitioningCriteria": {
+    "enum": ["TAC", "SUBPLMN", "GEOAREA", "SNSSAI", "DNN"]
+  },
+  "NotificationFlag": {
+    "enum": ["ACTIVATE", "DEACTIVATE", "RETRIEVAL"]
+  },
+  "DiscoveredAPIs": {
+    "mandatory_attributes": {},
+    "optional_attributes": {
+      "serviceAPIDescriptions": "ServiceAPIDescription"
+    }
+  },
+  "ServiceSecurity": {
+    "mandatory_attributes": {
+      "securityInfo": "SecurityInformation",
+      "notificationDestination": "URI"
+    },
+    "optional_attributes": {
+      "requestTestNotification": "boolean",
+      "websockNotifConfig": "WebsockNotifConfig",
+      "supportedFeatures": "SupportedFeatures"
+    }
+  },
+  "SecurityInformation": {
+    "mandatory_attributes": {
+      "prefSecurityMethods": "SecurityMethod"
+    },
+    "optional_attributes": {
+      "interfaceDetails": "InterfaceDescription",
+      "aefId": "string",
+      "apiId": "string",
+      "selSecurityMethod": "SecurityMethod",
+      "authenticationInfo": "string",
+      "authorizationInfo": "string"
+    },
+    "oneOf": ["interfaceDetails", "aefId"]
+  },
+  "SupportedFeatures": {
+    "regex": "^[A-Fa-f0-9]*$"
+  },
+  "SecurityNotification": {
+    "mandatory_attributes": {
+      "apiInvokerId": "string",
+      "apiIds": "string",
+      "cause": "Cause"
+    },
+    "optional_attributes": {
+      "aefId": "string"
+    }
+  },
+  "Cause": {
+    "enum": ["OVERLIMIT_USAGE", "UNEXPECTED_REASON"]
+  },
+  "AccessTokenReq": {
+    "mandatory_attributes": {
+      "grant_type": "GrantType",
+      "client_id": "string"
+    },
+    "optional_attributes": {
+      "client_secret": "string",
+      "scope": "string"
+    }
+  },
+  "AccessTokenReq29571": {
+    "mandatory_attributes": {
+      "grant_type": "GrantType",
+      "nfInstanceId": "UUID",
+      "scope": "ScopeRegex"
+    },
+    "optional_attributes": {
+      "nfType": "NFType",
+      "targetNfType": "NFType",
+      "targetNfInstanceId": "UUID",
+      "requesterPlmn": "PlmnId",
+      "requesterPlmnList": "PlmnId",
+      "requesterSnssaiList": "Snssai",
+      "requesterFqdn": "Fqdn",
+      "requesterSnpnList": "PlmnIdNid",
+      "targetPlmn": "PlmnId",
+      "targetSnpn": "PlmnIdNid",
+      "targetSnssaiList": "Snssai",
+      "targetNsiList": "string",
+      "targetNfSetId": "NfSetId",
+      "targetNfServiceSetId": "NfServiceSetId",
+      "hnrfAccessTokenUri": "URI",
+      "sourceNfInstanceId": "UUID"
+    }
+  },
+  "NfSetId": {
+    "regex": "set[a-zA-Z0-9\\-]+\\.(nrf|udm|amf|smf|ausf|nef|pcf|smsf|nssf|udr|lmf|gmlc|5g_eir|sepp|upf|n3iwf|af|udsf|bsf|chf|nwdaf|pcscf|cbcf|hss|ucmf|sor_af|spaf|mme|scsas|scef|scp|nssaaf|icscf|scscf|dra|ims_as|aanf|5g_ddnmf|nsacf|mfaf|easdf|dccf|mb_smf|tsctsf|adrf|gba_bsf|cef|mb_upf|nswof|pkmf|mnpf|sms_gmsc|sms_iwmsc|mbsf|mbstf|panf)set\\.5gc(\\.nid[A-Fa-f0-9]{11})?\\.mnc[0-9]{3}\\.mcc[0-9]{3}"
+  },
+  "NfServiceSetId": {
+    "regex": "set[a-zA-Z0-9\\-]+\\.(nrf|udm|amf|smf|ausf|nef|pcf|smsf|nssf|udr|lmf|gmlc|5g_eir|sepp|upf|n3iwf|af|udsf|bsf|chf|nwdaf|pcscf|cbcf|hss|ucmf|sor_af|spaf|mme|scsas|scef|scp|nssaaf|icscf|scscf|dra|ims_as|aanf|5g_ddnmf|nsacf|mfaf|easdf|dccf|mb_smf|tsctsf|adrf|gba_bsf|cef|mb_upf|nswof|pkmf|mnpf|sms_gmsc|sms_iwmsc|mbsf|mbstf|panf)set\\.5gc(\\.nid[A-Fa-f0-9]{11})?\\.mnc[0-9]{3}\\.mcc[0-9]{3}"
+  },
+  "ScopeRegex": {
+    "regex": "^([a-zA-Z0-9_:-]+)( [a-zA-Z0-9_:-]+)*$"
+  },
+  "Fqdn": {
+    "regex": "^([0-9A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?\\.)+[A-Za-z]{2,63}\\.?$"
+  },
+  "UUID": {
+    "regex": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
+  },
+  "NFType": {
+    "enum": [
+      "NRF",
+      "UDM",
+      "AMF",
+      "SMF",
+      "AUSF",
+      "NEF",
+      "PCF",
+      "SMSF",
+      "NSSF",
+      "UDR",
+      "LMF",
+      "GMLC",
+      "5G_EIR",
+      "SEPP",
+      "UPF",
+      "N3IWF",
+      "AF",
+      "UDSF",
+      "BSF",
+      "CHF",
+      "NWDAF",
+      "PCSCF",
+      "CBCF",
+      "HSS",
+      "UCMF",
+      "SOR_AF",
+      "SPAF",
+      "MME",
+      "SCSAS",
+      "SCEF",
+      "SCP",
+      "NSSAAF",
+      "ICSCF",
+      "SCSCF",
+      "DRA",
+      "IMS_AS",
+      "AANF",
+      "5G_DDNMF",
+      "NSACF",
+      "MFAF",
+      "EASDF",
+      "DCCF",
+      "MB_SMF",
+      "TSCTSF",
+      "ADRF",
+      "GBA_BSF",
+      "CEF",
+      "MB_UPF",
+      "NSWOF",
+      "PKMF",
+      "MNPF",
+      "SMS_GMSC",
+      "SMS_IWMSC",
+      "MBSF",
+      "MBSTF",
+      "PANF"
+    ]
+  },
+  "PlmnId": {
+    "mandatory_attributes": {
+      "mcc": "Mcc",
+      "mnc": "Mnc"
+    },
+    "optional_attributes": {}
+  },
+  "PlmnIdNid": {
+    "mandatory_attributes": {
+      "mcc": "Mcc",
+      "mnc": "Mnc"
+    },
+    "optional_attributes": {
+      "nid": "Nid"
+    }
+  },
+  "Mcc": {
+    "regex": "^[0-9]{3}$"
+  },
+  "Mnc": {
+    "regex": "^[0-9]{2,3}$"
+  },
+  "Snssai": {
+    "mandatory_attributes": {
+      "sst": "integer"
+    },
+    "optional_attributes": {
+      "sd": "SlideDifferentiator"
+    }
+  },
+  "SlideDifferentiator": {
+    "regex": "^[A-Fa-f0-9]{6}$"
+  },
+  "Nid": {
+    "regex": "^[A-Fa-f0-9]{11}$"
+  },
+  "AccessTokenRsp": {
+    "mandatory_attributes": {
+      "access_token": "string",
+      "token_type": "TokenType",
+      "expires_in": "integer"
+    },
+    "optional_attributes": {
+      "scope": "string"
+    }
+  },
+  "GrantType": {
+    "enum": ["client_credentials"]
+  },
+  "TokenType": {
+    "enum": ["Bearer"]
+  },
+  "AccessTokenErr": {
+    "mandatory_attributes": {
+      "error": "ErrorType"
+    },
+    "optional_attributes": {
+      "error_description": "string",
+      "error_uri": "string"
+    }
+  },
+  "ErrorType": {
+    "enum": [
+      "invalid_request",
+      "invalid_client",
+      "invalid_grant",
+      "unauthorized_client",
+      "unsupported_grant_type",
+      "invalid_scope"
+    ]
+  },
+  "APIProviderEnrolmentDetails": {
+    "mandatory_attributes": {
+      "regSec": "string",
+      "apiProvDomId": "string"
+    },
+    "optional_attributes": {
+      "apiProvFuncs": "APIProviderFunctionDetails",
+      "apiProvDomInfo": "string",
+      "suppFeat": "SupportedFeatures",
+      "failReason": "string"
+    }
+  },
+  "APIProviderFunctionDetails": {
+    "mandatory_attributes": {
+      "regInfo": "RegistrationInformation",
+      "apiProvFuncRole": "ApiProviderFuncRole",
+      "apiProvFuncId": "string"
+    },
+    "optional_attributes": {
+      "apiProvFuncInfo": "string"
+    }
+  },
+  "RegistrationInformation": {
+    "mandatory_attributes": {
+      "apiProvPubKey": "string",
+      "apiProvCert": "string"
+    },
+    "optional_attributes": {}
+  },
+  "ApiProviderFuncRole": {
+    "enum": ["AEF", "APF", "AMF"]
+  },
+  "InvocationLog": {
+    "mandatory_attributes": {
+      "aefId": "string",
+      "apiInvokerId": "string",
+      "logs": "Log"
+    },
+    "optional_attributes": {
+      "log_id":"string",
+      "supportedFeatures": "SupportedFeatures"
+    }
+  },
+  "Log": {
+    "mandatory_attributes": {
+      "apiId": "string",
+      "apiName": "string",
+      "apiVersion": "string",
+      "resourceName": "string",
+      "protocol": "Protocol",
+      "result": "string"
+    },
+    "optional_attributes": {
+      "log_id": "string",
+      "uri": "URI",
+      "operation": "Operation",
+      "invocationTime": "string",
+      "invocationLatency": "integer",
+      "inputParameters": "Any",
+      "outputParameters": "Any",
+      "srcInterface": "InterfaceDescription",
+      "destInterface": "InterfaceDescription",
+      "fwdInterface": "string",
+      "supportedFeatures": "SupportedFeatures"
+    }
+  },
+  "Any": {
+    "Check": false
+  }
+}

--- a/perf_tests/libraries/helpers.py
+++ b/perf_tests/libraries/helpers.py
@@ -1,0 +1,141 @@
+import requests
+import re
+import pandas as pd
+from urllib.parse import urlparse
+from OpenSSL.crypto import (dump_certificate_request, dump_privatekey,
+                            PKey, TYPE_RSA, X509Req)
+from OpenSSL.SSL import FILETYPE_PEM
+import socket
+import copy
+
+
+def parse_url(input):
+    return urlparse(input)
+
+
+def get_db_host(input):
+    p = re.compile('^(http|https):\/\/([^:/]+):?([0-9]{1,6})?.*')
+    m = p.match(input)
+    if m:
+        if m.lastindex == 3:
+            return m[2], m[3]
+        return m[2], 80
+    else:
+        raise Exception('Host is not present at ' + input)
+
+
+def get_subscriber_and_subscription_from_location(input):
+    p = re.compile('^.*/v1/([a-zA-Z0-9]+)/subscriptions/([a-zA-Z0-9]+)/?')
+    m = p.match(input)
+    if m:
+        if m.lastindex == 2:
+            return m[1], m[2]
+        raise Exception('Only match ' + m.lastindex + ' and the expected is 2')
+    else:
+        raise Exception('Host is not present at ' + input)
+
+
+def get_registration_id(input):
+    p = re.compile('^.*/v1/registrations/([a-zA-Z0-9]+)/?')
+    m = p.match(input)
+    if m:
+        if m.lastindex == 1:
+            return m[1]
+        raise Exception('Only match ' + m.lastindex + ' and the expected is 1')
+    else:
+        raise Exception('registration id is not present at ' + input)
+
+
+def store_in_file(file_path, data):
+    with open(file_path, 'wb') as f:
+        f.write(bytes(data, 'utf-8'))
+        f.close()
+
+
+def cert_tuple(cert_file, key_file):
+    return (cert_file, key_file)
+
+
+def add_dns_to_hosts(ip_address, host_name):
+    capif_dns = "{}      {}".format(ip_address, host_name)
+    dns_file = open("/etc/hosts", "a")
+    dns_file.write("{}\n".format(capif_dns))
+    dns_file.close()
+
+
+def create_csr(csr_file_path, private_key_path, cn):
+    # create public/private key
+    key = PKey()
+    key.generate_key(TYPE_RSA, 2048)
+
+    # Generate CSR
+    req = X509Req()
+    req.get_subject().CN = cn
+    req.get_subject().O = 'Telefonica I+D'
+    req.get_subject().OU = 'Innovation'
+    req.get_subject().L = 'Madrid'
+    req.get_subject().ST = 'Madrid'
+    req.get_subject().C = 'ES'
+    req.get_subject().emailAddress = 'inno@tid.es'
+    req.set_pubkey(key)
+    req.sign(key, 'sha256')
+
+    with open(csr_file_path, 'wb+') as f:
+        f.write(dump_certificate_request(FILETYPE_PEM, req))
+        f.close()
+        csr_request = dump_certificate_request(FILETYPE_PEM, req)
+    with open(private_key_path, 'wb+') as f:
+        f.write(dump_privatekey(FILETYPE_PEM, key))
+        f.close()
+
+    return csr_request
+
+
+def create_user_csr(username, cn=None):
+    csr_file_path = username+'.csr'
+    private_key_path = username + '.key'
+    if cn == None:
+        cn = username
+    return create_csr(csr_file_path, private_key_path, cn)
+
+
+def get_ip_from_hostname(hostname):
+    return socket.gethostbyname(hostname)
+
+
+def remove_keys_from_object_helper(input, keys_to_remove):
+    print(keys_to_remove)
+    print(input)
+    print(type(input))
+    if isinstance(input, list):
+        print('list')
+        for data in input:
+            remove_keys_from_object_helper(data, keys_to_remove)
+            return True
+
+    # Check Variable type
+    elif isinstance(input, dict):
+        print('dict')
+
+        for key in list(input.keys()):
+            print('key=' + key)
+            if key in keys_to_remove:
+                print('Remove ' + key + ' from object')
+                del input[key]
+            elif isinstance(input[key], dict) or isinstance(input[key], list):
+                remove_keys_from_object_helper(input[key], keys_to_remove)
+    else:
+        return True
+    return input
+
+
+def remove_key_from_object(input, key_to_remove):
+    input_copy = copy.deepcopy(input)
+    remove_keys_from_object_helper(input_copy, [key_to_remove])
+    return input_copy
+
+
+def create_scope(aef_id, api_name):
+    data = "3gpp#" + aef_id + ":" + api_name
+
+    return data

--- a/perf_tests/libraries/security_api/bodyRequests.py
+++ b/perf_tests/libraries/security_api/bodyRequests.py
@@ -1,0 +1,95 @@
+def create_service_security_body(notification_destination, aef_id=None):
+    data = {
+        "notificationDestination": notification_destination,
+        "supportedFeatures": "fffffff",
+        "securityInfo": [{
+            "authenticationInfo": "authenticationInfo",
+            "authorizationInfo": "authorizationInfo",
+            "interfaceDetails": {
+                "ipv4Addr": "127.0.0.1",
+                "securityMethods": ["PSK"],
+                "port": 5248
+            },
+            "prefSecurityMethods": ["PSK", "PKI", "OAUTH"],
+        }
+        ],
+        "websockNotifConfig": {
+            "requestWebsocketUri": True,
+            "websocketUri": "websocketUri"
+        },
+        "requestTestNotification": True
+    }
+
+    if aef_id != None:
+        data['securityInfo'].append({
+            "authenticationInfo": "authenticationInfo",
+            "authorizationInfo": "authorizationInfo",
+            "prefSecurityMethods": ["PSK", "PKI", "OAUTH"],
+            "aefId": aef_id
+        })
+
+    return data
+
+
+def create_service_security_from_discover_response(notification_destination, discover_response):
+    data = {
+        "notificationDestination": notification_destination,
+        "supportedFeatures": "fffffff",
+        "securityInfo": [],
+        "websockNotifConfig": {
+            "requestWebsocketUri": True,
+            "websocketUri": "websocketUri"
+        },
+        "requestTestNotification": True
+    }
+    service_api_descriptions = discover_response.json()['serviceAPIDescriptions']
+    for service_api_description in service_api_descriptions:
+        for aef_profile in service_api_description['aefProfiles']:
+            data['securityInfo'].append({
+                "authenticationInfo": "authenticationInfo",
+                "authorizationInfo": "authorizationInfo",
+                "prefSecurityMethods": ["PSK", "PKI", "OAUTH"],
+                "aefId": aef_profile['aefId'],
+                "apiId": service_api_description['apiId']
+            })
+    return data
+
+
+def create_security_notification_body(api_invoker_id, api_ids, cause="OVERLIMIT_USAGE", aef_id=None):
+    # cause must be one of [ OVERLIMIT_USAGE, UNEXPECTED_REASON ]
+    data = {
+        "apiIds": api_ids,
+        "apiInvokerId": api_invoker_id,
+        "cause": cause
+    }
+
+    if isinstance(api_ids,list):
+        data['apiIds'] = api_ids
+    else:
+        data['apiIds'] = [ api_ids ]
+
+    if aef_id != None:
+        data['aefId'] = aef_id
+    
+
+    return data
+
+
+def create_access_token_req_body(client_id, scope, client_secret=None,grant_type="client_credentials"):
+    data = {
+        "client_id": client_id,
+        "grant_type": grant_type,
+        "scope": scope
+    }
+
+    if client_secret != None:
+        data['client_secret'] = client_secret
+
+    return data
+
+def get_api_ids_from_discover_response(discover_response):
+    api_ids=[]
+    service_api_descriptions = discover_response.json()['serviceAPIDescriptions']
+    for service_api_description in service_api_descriptions:
+        api_ids.append(service_api_description['apiId'])
+    return api_ids

--- a/perf_tests/requirements.txt
+++ b/perf_tests/requirements.txt
@@ -1,0 +1,7 @@
+# Requirements file for tests.
+robotframework-mongodb-library==3.2
+requests==2.28.1
+configparser==5.3.0
+redis==4.5.4
+rfc3987==1.3.8
+robotframework-httpctrl

--- a/perf_tests/resources/api_invoker_management_requests/apiInvokerManagementRequests.robot
+++ b/perf_tests/resources/api_invoker_management_requests/apiInvokerManagementRequests.robot
@@ -1,0 +1,4 @@
+*** Settings ***
+Resource    /opt/robot-tests/tests/resources/common.resource
+Resource    /opt/robot-tests/tests/resources/common/basicRequests.robot
+

--- a/perf_tests/resources/common.resource
+++ b/perf_tests/resources/common.resource
@@ -1,0 +1,77 @@
+*** Settings ***
+Library     /opt/robot-tests/tests/libraries/helpers.py
+Resource    /opt/robot-tests/tests/resources/common/basicRequests.robot
+
+
+*** Variables ***
+${INVOKER_USERNAME}             ROBOT_TESTING_INVOKER
+${PROVIDER_USERNAME}            ROBOT_TESTING_PROVIDER
+${APF_PROVIDER_USERNAME}        APF_${PROVIDER_USERNAME}
+${AEF_PROVIDER_USERNAME}        AEF_${PROVIDER_USERNAME}
+${AMF_PROVIDER_USERNAME}        AMF_${PROVIDER_USERNAME}
+
+${INVOKER_NOT_REGISTERED}       not-valid
+${INVOKER_ROLE}                 invoker
+${PROVIDER_ROLE}                provider
+
+${CAPIF_HOSTNAME}               capifcore
+${CAPIF_HTTP_PORT}
+${CAPIF_HTTPS_PORT}
+${CAPIF_IP}                     127.0.0.1
+${CAPIF_CALLBACK_IP}            host.docker.internal
+${CAPIF_CALLBACK_PORT}          8086
+
+${DISCOVER_URL}                 /service-apis/v1/allServiceAPIs?api-invoker-id=
+
+
+*** Keywords ***
+Reset Testing Environment
+    Log    Db capif.invokerdetails collection will be removed in order to isolate each test.
+
+    Clean Test Information By HTTP Requests
+
+Check Location Header
+    [Documentation]    This keyword will check location header at response according to regular expression provided as argument
+    [Arguments]    ${resp}    ${regular_expression}
+
+    ${event_url}=    Parse Url    ${resp.headers['Location']}
+
+    Should Match Regexp    ${event_url.path}    ${regular_expression}
+    RETURN    ${event_url}
+
+Check Event Location Header
+    [Arguments]    ${resp}
+
+    ${event_url}=    Check Location Header    ${resp}    ${LOCATION_EVENT_RESOURCE_REGEX}
+
+    ${subscriber_id}    ${subscription_id}=    Get Subscriber And Subscription From Location    ${event_url.path}
+
+    RETURN    ${subscriber_id}    ${subscription_id}
+
+Check Problem Details
+    [Arguments]    ${resp}    &{input_parameters}
+    Check Variable    ${resp.json()}    ProblemDetails
+    FOR    ${input}    IN    @{input_parameters}
+        Log    ${input}=${input_parameters['${input}']}
+        Should Match    "${resp.json()['${input}']}"    "${input_parameters['${input}']}"
+    END
+
+Check Response Variable Type And Values
+    [Arguments]    ${resp}    ${status_code}    ${variable_type}    &{input_parameters}
+    Status Should Be    ${status_code}    ${resp}
+    Check Variable    ${resp.json()}    ${variable_type}
+    FOR    ${input}    IN    @{input_parameters}
+        Log    ${input}=${input_parameters['${input}']}
+        Should Match Regexp    "${resp.json()['${input}']}"    "${input_parameters['${input}']}"
+    END
+
+Remove Keys From Object
+    [Arguments]    ${input}    @{keys_to_remove}
+
+    ${filtered_input}=    Remove Keys From Object Helper    ${input}    ${keys_to_remove}
+
+    RETURN    ${filtered_input}
+
+Test ${TEST NAME} Currently Not Supported
+    Log    Test "${TEST NAME}" Currently not supported    WARN
+    Skip    Test "${TEST NAME}" Currently not supported

--- a/perf_tests/resources/common/basicRequests.robot
+++ b/perf_tests/resources/common/basicRequests.robot
@@ -1,0 +1,384 @@
+*** Settings ***
+Documentation       This resource file contains the basic requests used by Capif. NGINX_HOSTNAME and CAPIF_AUTH can be set as global variables, depends on environment used
+
+Library             RequestsLibrary
+Library             Collections
+Library             OperatingSystem
+Library             XML
+
+
+*** Variables ***
+${CAPIF_AUTH}
+${CAPIF_BEARER}
+
+${LOCATION_INVOKER_RESOURCE_REGEX}
+...                                     ^/api-invoker-management/v1/onboardedInvokers/[0-9a-zA-Z]+
+${LOCATION_EVENT_RESOURCE_REGEX}
+...                                     ^/capif-events/v1/[0-9a-zA-Z]+/subscriptions/[0-9a-zA-Z]+
+${LOCATION_INVOKER_RESOURCE_REGEX}
+...                                     ^/api-invoker-management/v1/onboardedInvokers/[0-9a-zA-Z]+
+${LOCATION_PUBLISH_RESOURCE_REGEX}
+...                                     ^/published-apis/v1/[0-9a-zA-Z]+/service-apis/[0-9a-zA-Z]+
+${LOCATION_SECURITY_RESOURCE_REGEX}
+...                                     ^/capif-security/v1/trustedInvokers/[0-9a-zA-Z]+
+${LOCATION_PROVIDER_RESOURCE_REGEX}
+...                                     ^/api-provider-management/v1/registrations/[0-9a-zA-Z]+
+${LOCATION_LOGGING_RESOURCE_REGEX}
+...                                     ^/api-invocation-logs/v1/[0-9a-zA-Z]+/logs/[0-9a-zA-Z]+
+
+${INVOKER_ROLE}                         invoker
+${AMF_ROLE}                             amf
+${APF_ROLE}                             apf
+${AEF_ROLE}                             aef
+
+
+*** Keywords ***
+Create CAPIF Session
+    [Documentation]    Create needed session and headers.
+    ...    If server input data is set to NONE, it will try to use NGINX_HOSTNAME variable.
+    [Arguments]    ${server}=${NONE}    ${access_token}=${NONE}    ${verify}=${NONE}
+
+    IF    "${server}" != "${NONE}"
+        Create Session    apisession    ${server}    verify=${verify}
+    END
+
+    ${headers}=    Create Dictionary
+    IF    "${access_token}" != "${NONE}"
+        ${headers}=    Create Dictionary    Authorization=Bearer ${access_token}
+    END
+
+    RETURN    ${headers}
+
+Post Request Capif
+    [Timeout]    60s
+    [Arguments]    ${endpoint}    ${json}=${NONE}    ${server}=${NONE}    ${access_token}=${NONE}    ${auth}=${NONE}    ${verify}=${FALSE}    ${cert}=${NONE}    ${username}=${NONE}    ${data}=${NONE}
+
+    ${headers}=    Create CAPIF Session    ${server}    ${access_token}    ${verify}
+
+    IF    '${username}' != '${NONE}'
+        ${cert}=    Set variable    ${{ ('${username}.crt','${username}.key') }}
+    END
+
+    ${resp}=    POST On Session
+    ...    apisession
+    ...    ${endpoint}
+    ...    headers=${headers}
+    ...    json=${json}
+    ...    expected_status=any
+    ...    verify=${verify}
+    ...    cert=${cert}
+    ...    data=${data}
+    RETURN    ${resp}
+
+Get Request Capif
+    [Timeout]    60s
+    [Arguments]    ${endpoint}    ${server}=${NONE}    ${access_token}=${NONE}    ${auth}=${NONE}    ${verify}=${FALSE}    ${cert}=${NONE}    ${username}=${NONE}
+
+    ${headers}=    Create CAPIF Session    ${server}    ${access_token}
+
+    IF    '${username}' != '${NONE}'
+        ${cert}=    Set variable    ${{ ('${username}.crt','${username}.key') }}
+    END
+
+    ${resp}=    GET On Session
+    ...    apisession
+    ...    ${endpoint}
+    ...    headers=${headers}
+    ...    expected_status=any
+    ...    verify=${verify}
+    ...    cert=${cert}
+    RETURN    ${resp}
+
+Put Request Capif
+    [Timeout]    60s
+    [Arguments]    ${endpoint}    ${json}=${NONE}    ${server}=${NONE}    ${access_token}=${NONE}    ${auth}=${NONE}    ${verify}=${FALSE}    ${cert}=${NONE}    ${username}=${NONE}
+
+    ${headers}=    Create CAPIF Session    ${server}    ${access_token}
+
+    IF    '${username}' != '${NONE}'
+        ${cert}=    Set variable    ${{ ('${username}.crt','${username}.key') }}
+    END
+
+    ${resp}=    PUT On Session
+    ...    apisession
+    ...    ${endpoint}
+    ...    headers=${headers}
+    ...    json=${json}
+    ...    expected_status=any
+    ...    verify=${verify}
+    ...    cert=${cert}
+
+    RETURN    ${resp}
+
+Patch Request Capif
+    [Timeout]    60s
+    [Arguments]    ${endpoint}    ${json}=${NONE}    ${server}=${NONE}    ${access_token}=${NONE}    ${auth}=${NONE}    ${verify}=${FALSE}    ${cert}=${NONE}    ${username}=${NONE}
+
+    ${headers}=    Create CAPIF Session    ${server}    ${access_token}
+
+    IF    '${username}' != '${NONE}'
+        ${cert}=    Set variable    ${{ ('${username}.crt','${username}.key') }}
+    END
+
+    ${resp}=    PATCH On Session
+    ...    apisession
+    ...    ${endpoint}
+    ...    headers=${headers}
+    ...    json=${json}
+    ...    expected_status=any
+    ...    verify=${verify}
+    ...    cert=${cert}
+
+    RETURN    ${resp}
+
+Delete Request Capif
+    [Timeout]    60s
+    [Arguments]    ${endpoint}    ${server}=${NONE}    ${access_token}=${NONE}    ${auth}=${NONE}    ${verify}=${FALSE}    ${cert}=${NONE}    ${username}=${NONE}
+
+    ${headers}=    Create CAPIF Session    ${server}    ${access_token}
+
+    IF    '${username}' != '${NONE}'
+        ${cert}=    Set variable    ${{ ('${username}.crt','${username}.key') }}
+    END
+
+    ${resp}=    DELETE On Session
+    ...    apisession
+    ...    ${endpoint}
+    ...    headers=${headers}
+    ...    expected_status=any
+    ...    verify=${verify}
+    ...    cert=${cert}
+
+    RETURN    ${resp}
+
+Register User At Jwt Auth
+    [Arguments]    ${username}    ${role}    ${password}=password    ${description}=Testing
+
+    ${cn}=    Set Variable    ${username}
+    # Create certificate and private_key for this machine.
+    IF    "${role}" == "${INVOKER_ROLE}"
+        ${cn}=    Set Variable    invoker
+        ${csr_request}=    Create User Csr    ${username}    ${cn}
+        Log    inside if cn=${cn}
+    ELSE
+        ${csr_request}=    Set Variable    ${None}
+    END
+
+    Log    cn=${cn}
+
+    &{body}=    Create Dictionary
+    ...    password=${password}
+    ...    username=${username}
+    ...    role=${role}
+    ...    description=${description}
+    ...    cn=${cn}
+
+    Create Session    jwtsession    ${CAPIF_HTTP_URL}    verify=True
+
+    ${resp}=    POST On Session    jwtsession    /register    json=${body}
+
+    Should Be Equal As Strings    ${resp.status_code}    201
+
+    ${get_auth_response}=    Get Auth For User    ${username}    ${password}
+
+    ${register_user_info}=    Create Dictionary
+    ...    netappID=${resp.json()['id']}
+    ...    csr_request=${csr_request}
+    ...    &{resp.json()}
+    ...    &{get_auth_response}
+
+    Log Dictionary    ${register_user_info}
+
+    IF    "ca_root" in @{register_user_info.keys()}
+        Store In File    ca.crt    ${register_user_info['ca_root']}
+    END
+
+    IF    "cert" in @{register_user_info.keys()}
+        Store In File    ${username}.crt    ${register_user_info['cert']}
+    END
+    IF    "private_key" in @{register_user_info.keys()}
+        Store In File    ${username}.key    ${register_user_info['private_key']}
+    END
+
+    RETURN    ${register_user_info}
+
+Register User At Jwt Auth Provider
+    [Arguments]    ${username}    ${role}    ${password}=password    ${description}=Testing
+
+    ${apf_username}=    Set Variable    APF_${username}
+    ${aef_username}=    Set Variable    AEF_${username}
+    ${amf_username}=    Set Variable    AMF_${username}
+
+    # Create a certificate for each kind of role under provider
+    ${csr_request}=    Create User Csr    ${username}    provider
+
+    ${apf_csr_request}=    Create User Csr    ${apf_username}    apf
+    ${aef_csr_request}=    Create User Csr    ${aef_username}    aef
+    ${amf_csr_request}=    Create User Csr    ${amf_username}    amf
+
+    # Register provider
+    &{body}=    Create Dictionary
+    ...    password=${password}
+    ...    username=${username}
+    ...    role=${role}
+    ...    description=${description}
+    ...    cn=${username}
+
+    Create Session    jwtsession    ${CAPIF_HTTP_URL}    verify=True
+
+    ${resp}=    POST On Session    jwtsession    /register    json=${body}
+
+    Should Be Equal As Strings    ${resp.status_code}    201
+
+    # Get Auth to obtain access_token
+    ${get_auth_response}=    Get Auth For User    ${username}    ${password}
+
+    ${register_user_info}=    Create Dictionary
+    ...    netappID=${resp.json()['id']}
+    ...    csr_request=${csr_request}
+    ...    apf_csr_request=${apf_csr_request}
+    ...    aef_csr_request=${aef_csr_request}
+    ...    amf_csr_request=${amf_csr_request}
+    ...    apf_username=${apf_username}
+    ...    aef_username=${aef_username}
+    ...    amf_username=${amf_username}
+    ...    &{resp.json()}
+    ...    &{get_auth_response}
+
+    Log Dictionary    ${register_user_info}
+
+    RETURN    ${register_user_info}
+
+Get Auth For User
+    [Arguments]    ${username}    ${password}
+
+    &{body}=    Create Dictionary    username=${username}    password=${password}
+
+    ${resp}=    POST On Session    jwtsession    /getauth    json=${body}
+
+    Should Be Equal As Strings    ${resp.status_code}    200
+
+    # Should Be Equal As Strings    ${resp.json()['message']}    Certificate created successfuly
+
+    RETURN    ${resp.json()}
+
+Clean Test Information By HTTP Requests
+    Create Session    jwtsession    ${CAPIF_HTTP_URL}    verify=True
+
+    ${resp}=    DELETE On Session    jwtsession    /testdata
+    Should Be Equal As Strings    ${resp.status_code}    200
+
+Invoker Default Onboarding
+    ${register_user_info}=    Register User At Jwt Auth
+    ...    username=${INVOKER_USERNAME}    role=${INVOKER_ROLE}
+
+    # Send Onboarding Request
+    ${request_body}=    Create Onboarding Notification Body
+    ...    http://${CAPIF_CALLBACK_IP}:${CAPIF_CALLBACK_PORT}/netapp_callback
+    ...    ${register_user_info['csr_request']}
+    ...    ${INVOKER_USERNAME}
+    ${resp}=    Post Request Capif
+    ...    ${register_user_info['ccf_onboarding_url']}
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    access_token=${register_user_info['access_token']}
+
+    Set To Dictionary    ${register_user_info}    api_invoker_id=${resp.json()['apiInvokerId']}
+    Log Dictionary    ${register_user_info}
+
+    # Assertions
+    Status Should Be    201    ${resp}
+    Check Variable    ${resp.json()}    APIInvokerEnrolmentDetails
+    Check Location Header    ${resp}    ${LOCATION_INVOKER_RESOURCE_REGEX}
+    # Store dummy signede certificate
+    Store In File    ${INVOKER_USERNAME}.crt    ${resp.json()['onboardingInformation']['apiInvokerCertificate']}
+
+    ${url}=    Parse Url    ${resp.headers['Location']}
+
+    RETURN    ${register_user_info}    ${url}    ${request_body}
+
+Provider Registration
+    [Arguments]    ${register_user_info}
+
+    # Create provider Registration Body
+    ${apf_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['apf_username']}
+    ...    ${register_user_info['apf_csr_request']}
+    ...    APF
+    ${aef_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['aef_username']}
+    ...    ${register_user_info['aef_csr_request']}
+    ...    AEF
+    ${amf_func_details}=    Create Api Provider Function Details
+    ...    ${register_user_info['amf_username']}
+    ...    ${register_user_info['amf_csr_request']}
+    ...    AMF
+    ${api_prov_funcs}=    Create List    ${apf_func_details}    ${aef_func_details}    ${amf_func_details}
+
+    ${request_body}=    Create Api Provider Enrolment Details Body
+    ...    ${register_user_info['access_token']}
+    ...    ${api_prov_funcs}
+
+    # Register Provider
+    ${resp}=    Post Request Capif
+    ...    /api-provider-management/v1/registrations
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    access_token=${register_user_info['access_token']}
+
+    # Check Results
+    Check Response Variable Type And Values    ${resp}    201    APIProviderEnrolmentDetails
+    ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_PROVIDER_RESOURCE_REGEX}
+
+    Log Dictionary    ${resp.json()}
+
+    FOR    ${prov}    IN    @{resp.json()['apiProvFuncs']}
+        Log Dictionary    ${prov}
+        Store In File    ${prov['apiProvFuncInfo']}.crt    ${prov['regInfo']['apiProvCert']}
+        IF    "${prov['apiProvFuncRole']}" == "APF"
+            Set To Dictionary    ${register_user_info}    apf_id=${prov['apiProvFuncId']}
+        ELSE IF    "${prov['apiProvFuncRole']}" == "AEF"
+            Set To Dictionary    ${register_user_info}    aef_id=${prov['apiProvFuncId']}
+        ELSE IF    "${prov['apiProvFuncRole']}" == "AMF"
+            Set To Dictionary    ${register_user_info}    amf_id=${prov['apiProvFuncId']}
+        ELSE
+            Fail    "${prov['apiProvFuncRole']} is not valid role"
+        END
+    END
+
+    Set To Dictionary
+    ...    ${register_user_info}
+    ...    provider_enrollment_details=${request_body}
+    ...    resource_url=${resource_url}
+    ...    provider_register_response=${resp}
+
+    RETURN    ${register_user_info}
+
+Provider Default Registration
+    #Register Provider
+    ${register_user_info}=    Register User At Jwt Auth Provider
+    ...    username=${PROVIDER_USERNAME}    role=${PROVIDER_ROLE}
+
+    ${register_user_info}=    Provider Registration    ${register_user_info}
+
+    Log Dictionary    ${register_user_info}
+    RETURN    ${register_user_info}
+
+Publish Service Api
+    [Arguments]    ${register_user_info_provider}    ${service_name}=service_1
+
+    ${request_body}=    Create Service Api Description    ${service_name}    ${register_user_info_provider['aef_id']}
+    ${resp}=    Post Request Capif
+    ...    /published-apis/v1/${register_user_info_provider['apf_id']}/service-apis
+    ...    json=${request_body}
+    ...    server=${CAPIF_HTTPS_URL}
+    ...    verify=ca.crt
+    ...    username=${register_user_info_provider['apf_username']}
+
+    Check Response Variable Type And Values    ${resp}    201    ServiceAPIDescription
+    Dictionary Should Contain Key    ${resp.json()}    apiId
+    ${resource_url}=    Check Location Header    ${resp}    ${LOCATION_PUBLISH_RESOURCE_REGEX}
+
+    RETURN    ${resp.json()}    ${resource_url}    ${request_body}

--- a/perf_tests/resources/common/httpServer.robot
+++ b/perf_tests/resources/common/httpServer.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Library           HttpLibrary
+
+*** Test Cases ***
+Example Test
+    [Tags]        jms-not-working
+    # Start the HTTP listener on port 8888
+    Create Http Server    8888
+    
+    # Handle incoming requests using a keyword
+    Handle Request    Handle Incoming Request
+    
+    # Stop the HTTP listener
+    Stop Http Server
+    
+*** Keywords ***
+Handle Incoming Request
+    # Get the request data using the built-in keywords
+    ${request_method}    Get Request Method
+    ${request_body}    Get Request Body
+    
+    # Do something with the request data, such as logging it or saving it to a variable
+    Log    Received HTTP request with method ${request_method} and body ${request_body}

--- a/perf_tests/resources/common/httpServerCtrl.robot
+++ b/perf_tests/resources/common/httpServerCtrl.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+
+Library         String
+Library         HttpCtrl.Client
+Library         HttpCtrl.Server
+
+Test Setup       Initialize HTTP Client And Server
+Test Teardown    Terminate HTTP Server
+
+*** Test Cases ***
+
+Receive And Reply To POST
+    [Tags]   jms
+    # ${request body}=   Set Variable   { "method": "POST" }
+    # Send HTTP Request Async   POST   /post   ${request body}
+
+    Wait For Request  300
+    Reply By   200
+
+    # ${method}=   Get Request Method
+    # ${url}=      Get Request Url
+    # ${body}=     Get Request Body
+    # ${body}=     Decode Bytes To String   ${body}   UTF-8
+
+    # Should Be Equal   ${method}   POST
+    # Should Be Equal   ${url}      /post
+    # Should Be Equal   ${body}     ${request body}
+
+*** Keywords ***
+
+Initialize HTTP Client And Server
+    # Initialize Client   127.0.0.1   8000
+    Start Server        127.0.0.1   8000
+
+Terminate HTTP Server
+    Stop Server

--- a/perf_tests/resources/performance.resource
+++ b/perf_tests/resources/performance.resource
@@ -1,0 +1,30 @@
+*** Variables ***
+
+${ITERATIONS}           2
+${THRESHOLD}            2.05
+
+*** Keywords ***
+
+Handle Timing
+    [Arguments]     ${elapsed}       ${iteration}        ${average}      ${success}
+    ${timespan}     Evaluate    ${elapsed.seconds}+(${elapsed.microseconds}/1000000.0)
+    Log To Console  <<<[${TEST_NAME}]${iteration}=${timespan}>>>
+    IF  ${timespan} < ${THRESHOLD}
+        Log To Console  Success
+        ${success}  Evaluate    ${success}+${1}
+    ELSE
+        Log To Console  Fail
+    END
+    IF  ${iteration} < ${1}
+        ${average}=     Set Variable    ${timespan}
+    ELSE
+        ${average}=     Evaluate    ((${average}*(${iteration}))+${timespan})/${iteration+1}
+    END
+    [Return]    ${success}      ${average}
+
+Handle End Results
+    [Arguments]     ${success}      ${average}
+    Log To Console      <<<[${TEST_NAME}];Success=${success}/${ITERATIONS};Average=${average}>>>
+    IF      ${success} < ${ITERATIONS}
+        Fail    Detected response times above threshold
+    END

--- a/perf_tests/resources/performance.resource
+++ b/perf_tests/resources/performance.resource
@@ -1,7 +1,7 @@
 *** Variables ***
 
 ${ITERATIONS}           2
-${THRESHOLD}            2.05
+${THRESHOLD}            3.05
 
 *** Keywords ***
 

--- a/services/runCapifPerfTests.sh
+++ b/services/runCapifPerfTests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+DOCKER_ROBOT_IMAGE=dockerhub.hi.inet/5ghacking/5gnow-robot-test-image
+DOCKER_ROBOT_IMAGE_VERSION=4.0
+cd ..
+REPOSITORY_BASE_FOLDER=${PWD}
+TEST_FOLDER=$REPOSITORY_BASE_FOLDER/perf_tests
+RESULT_FOLDER=$REPOSITORY_BASE_FOLDER/perf_results
+ROBOT_DOCKER_FILE_FOLDER=$REPOSITORY_BASE_FOLDER/tools/robot
+
+# nginx Hostname and http port (80 by default) to reach for tests_
+CAPIF_HOSTNAME=capifcore
+CAPIF_HTTP_PORT=8080
+CAPIF_HTTPS_PORT=443
+
+echo "HOSTNAME = $CAPIF_HOSTNAME"
+echo "CAPIF_HTTP_PORT = $CAPIF_HTTP_PORT"
+echo "CAPIF_HTTPS_PORT = $CAPIF_HTTPS_PORT"
+
+docker >/dev/null 2>/dev/null
+if [[ $? -ne 0 ]]
+then
+    echo "Docker maybe is not installed. Please check if docker CLI is present."
+    exit -1
+fi
+
+docker images|grep -Eq '^'$DOCKER_ROBOT_IMAGE'[ ]+[ ]'$DOCKER_ROBOT_IMAGE_VERSION''
+if [[ $? -ne 0 ]]
+then
+    read -p "Robot image is not present. To continue, Do you want to build it? (y/n)" build_robot_image
+    if [[ $build_robot_image == "y" ]]
+    then
+        echo "Building Robot docker image."
+        cd $ROBOT_DOCKER_FILE_FOLDER
+        docker build  -t $DOCKER_ROBOT_IMAGE:$DOCKER_ROBOT_IMAGE_VERSION .
+        cd $REPOSITORY_BASE_FOLDER
+    else
+        exit -2
+    fi
+fi
+
+mkdir -p $RESULT_FOLDER
+
+docker run -ti --rm --network="host" \
+    -v $TEST_FOLDER:/opt/robot-tests/tests \
+    -v $RESULT_FOLDER:/opt/robot-tests/results ${DOCKER_ROBOT_IMAGE}:${DOCKER_ROBOT_IMAGE_VERSION}  \
+    --variable CAPIF_HOSTNAME:$CAPIF_HOSTNAME \
+    --variable CAPIF_HTTP_PORT:$CAPIF_HTTP_PORT \
+    --variable CAPIF_HTTPS_PORT:$CAPIF_HTTPS_PORT $@


### PR DESCRIPTION
I've added the performance tests for CAPIF, using the original ones as base. These cover the correct usage of the API, not those that are expected to fail.

Everything is contained in a separate folder (`perf_tests` ), and there is an additional script in `services` (`runCapifPerfTests.sh`) that is equivalent to the original one.

At the moment the tests are controlled by two variables defined in `perf_tests/resources/performance.resource`: The number of iterations and the threshold in seconds to consider that each separate try is successful. For quick testing I've left the iterations set to 2, but on the real trials this should be changed to something much higher (we used 100 on the first release).

Let me know if something is not working as expected or needs to be changed, or if you have any question about this.