### PR TITLE
Fix ubuntu image used on robot Docker file, because python3.10 suppor…

### DIFF
--- a/tools/robot/Dockerfile
+++ b/tools/robot/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.elevenpaths.com/dockerhub-proxy/library/ubuntu:18.04
+FROM harbor.elevenpaths.com/dockerhub-proxy/library/ubuntu:20.04
 LABEL maintainer="Jorge Moratinos Salcines <jorge.moratinossalcines@telefonica.com>"
 LABEL version="2.0"
 LABEL description="Docker to run Robot Framework"


### PR DESCRIPTION
…t to ubuntu 18.04 was removed from deathsnakes repository