### PR TITLE
Hotfix issue with Werkzeug dependency went to 3.0.0 (a Flask dependency)

### DIFF
--- a/services/TS29222_CAPIF_API_Invoker_Management_API/requirements.txt
+++ b/services/TS29222_CAPIF_API_Invoker_Management_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 flask_jwt_extended == 4.4.4
 pyopenssl == 23.0.0

--- a/services/TS29222_CAPIF_API_Provider_Management_API/requirements.txt
+++ b/services/TS29222_CAPIF_API_Provider_Management_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 redis ==  4.5.4
 flask_executor == 1.0.0

--- a/services/TS29222_CAPIF_Access_Control_Policy_API/requirements.txt
+++ b/services/TS29222_CAPIF_Access_Control_Policy_API/requirements.txt
@@ -3,3 +3,4 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7

--- a/services/TS29222_CAPIF_Auditing_API/requirements.txt
+++ b/services/TS29222_CAPIF_Auditing_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 elasticsearch == 8.4.3
 flask_jwt_extended == 4.4.4

--- a/services/TS29222_CAPIF_Discover_Service_API/requirements.txt
+++ b/services/TS29222_CAPIF_Discover_Service_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 flask_jwt_extended == 4.4.4
 pyopenssl == 23.0.0

--- a/services/TS29222_CAPIF_Events_API/requirements.txt
+++ b/services/TS29222_CAPIF_Events_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 flask_jwt_extended == 4.4.4
 pyopenssl == 23.0.0

--- a/services/TS29222_CAPIF_Logging_API_Invocation_API/requirements.txt
+++ b/services/TS29222_CAPIF_Logging_API_Invocation_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 elasticsearch == 8.4.3
 flask_jwt_extended == 4.4.4

--- a/services/TS29222_CAPIF_Publish_Service_API/requirements.txt
+++ b/services/TS29222_CAPIF_Publish_Service_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 flask_jwt_extended == 4.4.4
 pyopenssl == 23.0.0

--- a/services/TS29222_CAPIF_Routing_Info_API/requirements.txt
+++ b/services/TS29222_CAPIF_Routing_Info_API/requirements.txt
@@ -3,3 +3,4 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7

--- a/services/TS29222_CAPIF_Security_API/requirements.txt
+++ b/services/TS29222_CAPIF_Security_API/requirements.txt
@@ -3,6 +3,7 @@ swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 flask_jwt_extended == 4.4.4
 pyopenssl == 23.0.0

--- a/services/easy_rsa/requirements.txt
+++ b/services/easy_rsa/requirements.txt
@@ -1,4 +1,5 @@
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 requests

--- a/services/jwt_auth/requirements.txt
+++ b/services/jwt_auth/requirements.txt
@@ -1,6 +1,7 @@
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
 Flask == 2.0.3
+Werkzeug == 2.3.7
 pymongo == 4.0.1
 flask_jwt_extended
 pyopenssl


### PR DESCRIPTION
Flask version 2.0.3 is having a dependency for the Python package "Werkzeug" >=2.3.7. But since Werkzeug just released a 3.0.0 version, with breaking changes in, Flask will get version 3.0.0 when building the apps, resulting in errors from multiple containers with "Werkzeug.urls" isn't found.

This PR is just a hotfix to pin the version of Werkzeug to 2.3.7 (last known working version in Flask) so it will continue to work for people checking the code out.